### PR TITLE
fix: skip macOS Keychain check on Linux/WSL and handle spawn errors

### DIFF
--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -532,7 +532,7 @@ export async function discoverAccounts(): Promise<DiscoveredAccount[]> {
       configDir: resolvedConfig,
     });
 
-    if (!(await checkKeychain(keychainService))) {
+    if (process.platform === "darwin" && !(await checkKeychain(keychainService))) {
       continue;
     }
 
@@ -730,7 +730,7 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
       homeDir: homedir(),
       configDir: resolvedDir,
     });
-    if (!(await checkKeychain(keychainService))) {
+    if (process.platform === "darwin" && !(await checkKeychain(keychainService))) {
       issues.push({ kind: "missing_keychain", message: `${keychainService} not found in Keychain` });
     }
 

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -92,6 +92,7 @@ async function execCommand(
         stdio: "inherit",
       });
       child.on("close", (code) => resolve({ code: code ?? 1, stdout: "", stderr: "" }));
+      child.on("error", () => resolve({ code: 1, stdout: "", stderr: "" }));
       return;
     }
 
@@ -119,6 +120,9 @@ async function execCommand(
     child.on("close", (code) => {
       resolve({ code: code ?? 1, stdout, stderr });
     });
+    child.on("error", () => {
+      resolve({ code: 1, stdout, stderr });
+    });
   });
 }
 
@@ -131,6 +135,9 @@ async function runLoginFlow(configDir: string): Promise<boolean> {
 }
 
 async function checkKeychain(service: string) {
+  if (process.platform !== "darwin") {
+    return false;
+  }
   const result = await execCommand("security", ["find-generic-password", "-s", service], { quiet: true });
   return result.code === 0;
 }


### PR DESCRIPTION
## Summary

Fixes #2

- **Guard `checkKeychain()` with `process.platform !== "darwin"`** — the `security` command (macOS Keychain) doesn't exist on Linux/WSL, causing `clausona init` to crash with an unhandled `EACCES` error.
- **Add `error` event handlers to `execCommand()` spawn calls** — prevents unhandled `Error: spawn ... EACCES` from crashing the process even if other commands are missing in the future.

## Test plan
- [x] Run `clausona init` on Linux/WSL — should no longer crash
- [x] Run `clausona init` on macOS — should still work as before (keychain check runs normally)
- [x] Verify `clausona status` shows keychain as unavailable on Linux without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)