### PR TITLE
fix: unalias claude before defining shell-init function

### DIFF
--- a/src/core/shell.test.ts
+++ b/src/core/shell.test.ts
@@ -7,6 +7,7 @@ describe("renderShellInit", () => {
     const shellInit = renderShellInit();
 
     expect(shellInit).toContain("claude()");
+    expect(shellInit).toContain("unalias claude");
     expect(shellInit).toContain("alias csn=clausona");
     expect(shellInit).toContain("CLAUDE_CONFIG_DIR");
     expect(shellInit).toContain("_clausona_resolve_config");

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -31,6 +31,7 @@ try {
   fi
 }
 
+unalias claude 2>/dev/null
 claude() {
   if [[ -z "\${CLAUDE_CONFIG_DIR:-}" ]]; then
     _clausona_resolve_config


### PR DESCRIPTION
## Summary

Fixes #4

When a user has an existing `alias claude=...` in their shell config (e.g. `.zshrc`), the function emitted by `clausona shell-init` never takes effect because aliases are expanded before function lookup. Profile switching silently fails.

This change emits `unalias claude 2>/dev/null` immediately before the function definition. The `2>/dev/null` swallows the harmless "no such alias" error for the 99% of users who don't have a `claude` alias.

This is the same defensive pattern used by tools like `nvm`, `pyenv`, and `direnv` in their shell integration scripts.

## Test plan
- [x] `pnpm test` — all 20 tests pass (added one assertion for the new `unalias claude` line)
- [x] Manually verified in zsh: with `alias claude='...'` set, `unalias claude` followed by `claude() { ... }` makes the function take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)