### PR TITLE
chore: add Biome lint and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --no-frozen-lockfile
+
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["**", "!**/dist", "!**/node_modules"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/build.mjs
+++ b/build.mjs
@@ -1,14 +1,11 @@
-import { build } from "esbuild";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { build } from "esbuild";
 
 // Stub out react-devtools-core — ink imports it but it's unnecessary for CLI
 const stubDir = "node_modules/.clausona-stubs";
 mkdirSync(stubDir, { recursive: true });
-writeFileSync(
-  path.join(stubDir, "react-devtools-core.js"),
-  "export default undefined;\n",
-);
+writeFileSync(path.join(stubDir, "react-devtools-core.js"), "export default undefined;\n");
 
 await build({
   entryPoints: ["src/index.tsx"],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build": "rm -rf dist && node build.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "lint": "biome check",
+    "lint:fix": "biome check --write"
   },
   "dependencies": {
     "@inkjs/ui": "2.0.0",
@@ -22,6 +24,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.13",
     "@types/node": "20.12.7",
     "@types/react": "19.2.2",
     "@types/react-test-renderer": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.13
+        version: 2.4.13
       '@types/node':
         specifier: 20.12.7
         version: 20.12.7
@@ -60,6 +63,59 @@ packages:
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
     engines: {node: '>=18'}
+
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -829,6 +885,41 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-darwin-x64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,19 @@
 import path from "node:path";
 import { createInterface } from "node:readline";
-
+import { trackUsage } from "./core/track-usage.js";
+import {
+  accent,
+  bold,
+  box,
+  dim,
+  green,
+  helpSection,
+  helpUsage,
+  secondary,
+  styledCost,
+  success,
+} from "./lib/cli-style.js";
+import { localTimezoneLabel, renderDoctor, renderList, renderUsageSummary } from "./lib/format.js";
 import {
   addProfile,
   discoverAccounts,
@@ -14,14 +27,11 @@ import {
   removeProfile,
   repairProfile,
   setActiveProfileByName,
-  syncPluginsJson,
-  updateProfileConfig,
   shellInit,
+  syncPluginsJson,
   uninstallClausona,
+  updateProfileConfig,
 } from "./lib/service.js";
-import { trackUsage } from "./core/track-usage.js";
-import { accent, bold, box, dim, green, helpSection, helpUsage, secondary, styledCost, success } from "./lib/cli-style.js";
-import { localTimezoneLabel, renderDoctor, renderList, renderUsageSummary } from "./lib/format.js";
 
 function jsonFlag(args: string[]) {
   return args.includes("--json");
@@ -356,7 +366,9 @@ export async function runCommand(command: string, args: string[]) {
         ...(current.orgName ? [`${secondary("Org".padEnd(12))}${current.orgName}`] : []),
         `${secondary("Config".padEnd(12))}${dim(configPath)}`,
         `${secondary("Keychain".padEnd(12))}${current.keychainService} ${keychainStatus}`,
-        ...(!current.isPrimary ? [`${secondary("Sessions".padEnd(12))}${current.mergeSessions ? "merged" : "separated"}`] : []),
+        ...(!current.isPrimary
+          ? [`${secondary("Sessions".padEnd(12))}${current.mergeSessions ? "merged" : "separated"}`]
+          : []),
         "",
         `${secondary("Today".padEnd(12))}${styledCost(current.usage.today.cost)}  ${dim(localTimezoneLabel())}`,
         `${secondary("Total".padEnd(12))}${styledCost(current.usage.total.cost)}`,
@@ -430,7 +442,7 @@ export async function runCommand(command: string, args: string[]) {
     }
 
     case "add": {
-      const fromIndex = args.findIndex((arg) => arg === "--from");
+      const fromIndex = args.indexOf("--from");
       const fromPath = fromIndex >= 0 ? args[fromIndex + 1] : undefined;
       const fromValueIndex = fromIndex >= 0 ? fromIndex + 1 : -1;
       const mergeSessions = args.includes("--merge-sessions");
@@ -461,7 +473,7 @@ export async function runCommand(command: string, args: string[]) {
 
     case "uninstall": {
       process.stdout.write(
-        [
+        `${[
           "",
           `  ${bold("This will completely uninstall clausona:")}`,
           `    ${dim("• Strip symlinks and restore backups for all non-primary profiles")}`,
@@ -470,7 +482,7 @@ export async function runCommand(command: string, args: string[]) {
           `    ${dim("• Delete ~/.clausona/ directory (registry, usage, backups)")}`,
           `    ${dim("• Delete app files and launcher binary")}`,
           "",
-        ].join("\n") + "\n",
+        ].join("\n")}\n`,
       );
 
       const confirmed = await new Promise<boolean>((resolve) => {
@@ -508,7 +520,12 @@ export async function runCommand(command: string, args: string[]) {
         throw new Error("No Claude Code accounts found. Run `claude login` first.");
       }
       const mergeSessions = args.includes("--merge-sessions") || undefined;
-      const profileNames = Object.fromEntries(accounts.map((account) => [account.configDir, account.isPrimary ? "default" : path.basename(account.configDir).replace(/^\.claude-/, "")]));
+      const profileNames = Object.fromEntries(
+        accounts.map((account) => [
+          account.configDir,
+          account.isPrimary ? "default" : path.basename(account.configDir).replace(/^\.claude-/, ""),
+        ]),
+      );
       const defaultProfile = Object.values(profileNames)[0] ?? "default";
       await initializeRegistry({ accounts, profileNames, defaultProfile, mergeSessions });
       return success(`Initialized ${bold(String(accounts.length))} profile(s)`);
@@ -533,9 +550,6 @@ export async function bootstrapInitFromCurrentState() {
   return {
     accounts,
     profileNames,
-    defaultProfile:
-      existing?.activeProfile ??
-      Object.values(profileNames)[0] ??
-      "default",
+    defaultProfile: existing?.activeProfile ?? Object.values(profileNames)[0] ?? "default",
   };
 }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -5,7 +5,13 @@ export function evaluateSymlinkHealth({
   items,
 }: {
   isPrimary: boolean;
-  items: Array<{ name: string; isSymlink: boolean; pointsToPrimary: boolean; targetExists: boolean; existsInPrimary: boolean }>;
+  items: Array<{
+    name: string;
+    isSymlink: boolean;
+    pointsToPrimary: boolean;
+    targetExists: boolean;
+    existsInPrimary: boolean;
+  }>;
 }): DoctorIssue[] {
   if (isPrimary) {
     return [];

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,13 +1,7 @@
 import crypto from "node:crypto";
 import path from "node:path";
 
-export function claudeJsonPathForConfigDir({
-  homeDir,
-  configDir,
-}: {
-  homeDir: string;
-  configDir: string;
-}): string {
+export function claudeJsonPathForConfigDir({ homeDir, configDir }: { homeDir: string; configDir: string }): string {
   const primary = path.join(homeDir, ".claude");
   if (configDir === primary) {
     return path.join(homeDir, ".claude.json");
@@ -16,23 +10,13 @@ export function claudeJsonPathForConfigDir({
   return path.join(configDir, ".claude.json");
 }
 
-export function keychainServiceForConfigDir({
-  homeDir,
-  configDir,
-}: {
-  homeDir: string;
-  configDir: string;
-}): string {
+export function keychainServiceForConfigDir({ homeDir, configDir }: { homeDir: string; configDir: string }): string {
   const primary = path.join(homeDir, ".claude");
   if (configDir === primary) {
     return "Claude Code-credentials";
   }
 
-  const hash = crypto
-    .createHash("sha256")
-    .update(configDir)
-    .digest("hex")
-    .slice(0, 8);
+  const hash = crypto.createHash("sha256").update(configDir).digest("hex").slice(0, 8);
 
   return `Claude Code-credentials-${hash}`;
 }

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -24,10 +24,10 @@ try {
   }
 } catch {}
 " 2>/dev/null)
-  if [[ "\$result" == "__PRIMARY__" ]]; then
+  if [[ "$result" == "__PRIMARY__" ]]; then
     unset CLAUDE_CONFIG_DIR
-  elif [[ -n "\$result" ]]; then
-    export CLAUDE_CONFIG_DIR="\$result"
+  elif [[ -n "$result" ]]; then
+    export CLAUDE_CONFIG_DIR="$result"
   fi
 }
 
@@ -37,11 +37,11 @@ claude() {
     _clausona_resolve_config
   fi
   clausona _sync-plugins 2>/dev/null
-  command claude "\$@"
-  local rc=\$?
+  command claude "$@"
+  local rc=$?
   unset CLAUDE_CONFIG_DIR
   clausona _track-usage 2>/dev/null
-  return \$rc
+  return $rc
 }
 
 alias csn=clausona

--- a/src/core/track-usage.ts
+++ b/src/core/track-usage.ts
@@ -1,10 +1,8 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { realpath } from "node:fs/promises";
-
-import { claudeJsonPathForConfigDir } from "./paths.js";
 import type { Registry, UsageStore } from "../types.js";
+import { claudeJsonPathForConfigDir } from "./paths.js";
 
 const CLAUSONA_DIR = path.join(homedir(), ".clausona");
 const REGISTRY_PATH = path.join(CLAUSONA_DIR, "profiles.json");
@@ -133,7 +131,8 @@ export async function seedSeenSessions(profileName: string, configDir: string): 
   if (!usage[profileName]) {
     usage[profileName] = { records: [], seenSessions: {} };
   }
-  const seen = usage[profileName].seenSessions ??= {};
+  usage[profileName].seenSessions ??= {};
+  const seen = usage[profileName].seenSessions;
 
   let changed = false;
   for (const [projPath, projData] of Object.entries(projects)) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,10 @@
-import { render } from "ink";
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { render } from "ink";
 
 import { runCommand } from "./commands.js";
 import { trackUsage } from "./core/track-usage.js";
-import { fail as xMark, accent } from "./lib/cli-style.js";
+import { accent, fail as xMark } from "./lib/cli-style.js";
 import { resolveProfileEnv } from "./lib/service.js";
 import { App } from "./tui/App.js";
 import type { ParsedCommand } from "./types.js";
@@ -30,7 +31,7 @@ const TUI_SCREENS = new Set(["dashboard", "use", "doctor", "init"]);
 
 async function main() {
   const parsed = parseCommand(process.argv.slice(2));
-  
+
   // Create a proper input stream that won't throw Raw mode errors when piped
   const renderOptions = {
     stdout: process.stdout,
@@ -42,18 +43,18 @@ async function main() {
     process.stdout.write("Run 'clausona --help' for usage. The interactive TUI requires a terminal.\n");
     return;
   }
-  
+
   if (parsed.kind === "tui") {
     // Clear initial state
     if (process.stdout.isTTY) {
-      process.stdout.write('\x1bc'); // FULL reset
+      process.stdout.write("\x1bc"); // FULL reset
     }
-    
-    const { waitUntilExit, clear } = render(<App initialScreen="dashboard" />, renderOptions);
+
+    const { waitUntilExit } = render(<App initialScreen="dashboard" />, renderOptions);
 
     await waitUntilExit();
     if (process.stdout.isTTY) {
-      process.stdout.write('\x1bc'); // Full clear on exit
+      process.stdout.write("\x1bc"); // Full clear on exit
     }
     return;
   }
@@ -84,20 +85,25 @@ async function main() {
           process.stdout.write("Operation successful. (Interactive TUI skipped due to non-TTY environment)\n");
           return;
         }
-        
+
         if (process.stdout.isTTY) {
-          process.stdout.write('\x1bc'); // FULL reset
+          process.stdout.write("\x1bc"); // FULL reset
         }
-        
-        const { waitUntilExit, clear } = render(<App initialScreen={screen as "dashboard" | "use" | "doctor" | "init"} />, renderOptions);
+
+        const { waitUntilExit } = render(
+          <App initialScreen={screen as "dashboard" | "use" | "doctor" | "init"} />,
+          renderOptions,
+        );
 
         await waitUntilExit();
         if (process.stdout.isTTY) {
-          process.stdout.write('\x1bc'); // Full clear on exit
+          process.stdout.write("\x1bc"); // Full clear on exit
         }
         return;
       }
-      process.stderr.write(`  ${xMark} This command requires an argument.\n    Run ${accent(`clausona ${parsed.command} --help`)} for usage.\n`);
+      process.stderr.write(
+        `  ${xMark} This command requires an argument.\n    Run ${accent(`clausona ${parsed.command} --help`)} for usage.\n`,
+      );
       process.exitCode = 1;
       return;
     }
@@ -109,9 +115,10 @@ async function main() {
   }
 }
 
-import { realpathSync } from "node:fs";
-
-const entryReal = realpathSync(process.argv[1]!);
-if (import.meta.url === `file://${entryReal}`) {
-  void main();
+const entryPath = process.argv[1];
+if (entryPath) {
+  const entryReal = realpathSync(entryPath);
+  if (import.meta.url === `file://${entryReal}`) {
+    void main();
+  }
 }

--- a/src/lib/cli-style.ts
+++ b/src/lib/cli-style.ts
@@ -62,7 +62,13 @@ export function box(title: string, lines: string[]) {
     return `${v}  ${line}${" ".repeat(pad)}${v}`;
   });
 
-  return ["  " + titleLine, "  " + emptyLine, ...contentLines.map((l) => "  " + l), "  " + emptyLine, "  " + bottomLine].join("\n");
+  return [
+    `  ${titleLine}`,
+    `  ${emptyLine}`,
+    ...contentLines.map((l) => `  ${l}`),
+    `  ${emptyLine}`,
+    `  ${bottomLine}`,
+  ].join("\n");
 }
 
 export function helpSection(title: string, items: [string, string][]) {
@@ -77,6 +83,7 @@ export function helpUsage(text: string) {
 
 /** Strip ANSI escape codes to get visible length */
 export function stripAnsi(str: string) {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ESC (\x1b) is required to match ANSI escape sequences
   return str.replace(/\x1b\[[0-9;]*m/g, "");
 }
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,7 +1,21 @@
 import { symbol } from "../tui/theme.js";
 import type { DoctorProfileResult, ProfileListItem, UsageSummary } from "../types.js";
 
-import { accent, bold, dim, dimmer, green, heading, ok, padEnd as pad, red, secondary, styledCost, styledCount, fail as xMark } from "./cli-style.js";
+import {
+  accent,
+  bold,
+  dim,
+  dimmer,
+  green,
+  heading,
+  ok,
+  padEnd as pad,
+  red,
+  secondary,
+  styledCost,
+  styledCount,
+  fail as xMark,
+} from "./cli-style.js";
 
 // ─── Timezone ────────────────────────────────────────────────────────
 export function localTimezoneLabel(): string {
@@ -41,8 +55,8 @@ export function renderList(items: ProfileListItem[]) {
     { label: "INPUT", w: 14 },
     { label: "OUTPUT", w: 10 },
   ];
-  const headerLine = "    " + cols.map((c) => secondary(c.label.padEnd(c.w))).join("");
-  const sep = "    " + dimmer("─".repeat(cols.reduce((s, c) => s + c.w, 0)));
+  const headerLine = `    ${cols.map((c) => secondary(c.label.padEnd(c.w))).join("")}`;
+  const sep = `    ${dimmer("─".repeat(cols.reduce((s, c) => s + c.w, 0)))}`;
 
   const rows = items.map((item) => {
     const marker = item.isActive ? accent("▸") : " ";
@@ -58,8 +72,13 @@ export function renderList(items: ProfileListItem[]) {
 }
 
 // ─── Usage Summary ──────────────────────────────────────────────────
-export function renderUsageSummary(data: Record<string, UsageSummary> | UsageSummary, profileName?: string, period?: string) {
-  const periodLabel = period === "today" ? "Today" : period === "week" ? "This week" : period === "month" ? "This month" : "All time";
+export function renderUsageSummary(
+  data: Record<string, UsageSummary> | UsageSummary,
+  profileName?: string,
+  period?: string,
+) {
+  const periodLabel =
+    period === "today" ? "Today" : period === "week" ? "This week" : period === "month" ? "This month" : "All time";
   const tzLabel = localTimezoneLabel();
 
   // Single profile
@@ -84,8 +103,8 @@ export function renderUsageSummary(data: Record<string, UsageSummary> | UsageSum
     { label: "INPUT", w: 14 },
     { label: "OUTPUT", w: 14 },
   ];
-  const headerLine = "    " + cols.map((c) => secondary(c.label.padEnd(c.w))).join("");
-  const sep = "    " + dimmer("─".repeat(cols.reduce((s, c) => s + c.w, 0)));
+  const headerLine = `    ${cols.map((c) => secondary(c.label.padEnd(c.w))).join("")}`;
+  const sep = `    ${dimmer("─".repeat(cols.reduce((s, c) => s + c.w, 0)))}`;
 
   const rows = Object.entries(entries).map(([name, s]) => {
     return `    ${name.padEnd(cols[0].w)}${pad(styledCost(s.cost), cols[1].w)}${pad(styledCount(s.inputTokens), cols[2].w)}${styledCount(s.outputTokens)}`;
@@ -97,7 +116,17 @@ export function renderUsageSummary(data: Record<string, UsageSummary> | UsageSum
 
   const totalRow = `    ${pad(bold("Total"), cols[0].w)}${pad(bold(styledCost(totalCost)), cols[1].w)}${pad(styledCount(totalIn), cols[2].w)}${styledCount(totalOut)}`;
 
-  return ["", heading(`${periodLabel}${period !== "all" ? ` ${dim(`(${tzLabel})`)}` : ""}`), "", headerLine, sep, ...rows, sep, totalRow, ""].join("\n");
+  return [
+    "",
+    heading(`${periodLabel}${period !== "all" ? ` ${dim(`(${tzLabel})`)}` : ""}`),
+    "",
+    headerLine,
+    sep,
+    ...rows,
+    sep,
+    totalRow,
+    "",
+  ].join("\n");
 }
 
 // ─── Doctor ─────────────────────────────────────────────────────────
@@ -116,7 +145,7 @@ export function renderDoctor(results: DoctorProfileResult[]) {
     });
 
     // Add repair suggestion for the last issue
-    const suggestion = `       ${dim(`Run ${accent("clausona repair " + result.name)} to fix`)}`;
+    const suggestion = `       ${dim(`Run ${accent(`clausona repair ${result.name}`)} to fix`)}`;
 
     return [title, statusLine, ...issueLines, suggestion].join("\n");
   });

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -1,7 +1,7 @@
-import { cp, lstat, mkdir, readFile, readdir, readlink, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { cp, lstat, mkdir, readdir, readFile, readlink, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
 
 import { evaluateSymlinkHealth } from "../core/doctor.js";
 import { seedSeenSessions } from "../core/track-usage.js";
@@ -19,6 +19,7 @@ function sharedLinkSkipSet(mergeSessions: boolean): Set<string> {
   if (!mergeSessions) return new Set([...BASE_SHARED_LINK_SKIP, "projects"]);
   return BASE_SHARED_LINK_SKIP;
 }
+
 import { claudeJsonPathForConfigDir, keychainServiceForConfigDir } from "../core/paths.js";
 import { setActiveProfile } from "../core/registry.js";
 import { renderShellInit } from "../core/shell.js";
@@ -304,7 +305,7 @@ export async function syncPluginsJson(configDir: string, primarySource: string):
           path.join(primarySource, "plugins", "marketplaces", name, ".git", "config"),
           "utf8",
         );
-        const remoteSection = gitConfig.match(/\[remote "origin"\][^\[]*url\s*=\s*(.+)/);
+        const remoteSection = gitConfig.match(/\[remote "origin"\][^[]*url\s*=\s*(.+)/);
         if (remoteSection) {
           const url = remoteSection[1].trim();
           const ghMatch = url.match(/github\.com[:/](.+?)(?:\.git)?$/);
@@ -333,10 +334,10 @@ export async function syncPluginsJson(configDir: string, primarySource: string):
     type InstalledPlugins = { version?: number; plugins?: Record<string, PluginEntry[]> };
     let installedJson = await readJson<InstalledPlugins | null>(installedPath, null);
     if (installedJson === null) {
-      installedJson = await readJson<InstalledPlugins>(
-        path.join(primarySource, "plugins", "installed_plugins.json"),
-        { version: 2, plugins: {} },
-      );
+      installedJson = await readJson<InstalledPlugins>(path.join(primarySource, "plugins", "installed_plugins.json"), {
+        version: 2,
+        plugins: {},
+      });
     }
 
     const syncedPlugins: Record<string, PluginEntry[]> = {};
@@ -430,10 +431,9 @@ async function mergePluginFiles(profilePluginsDir: string, primaryPluginsDir: st
   try {
     type PluginEntry = Record<string, unknown> & { installPath?: string };
     type InstalledPlugins = { version?: number; plugins?: Record<string, PluginEntry[]> };
-    const srcInstalled = await readJson<InstalledPlugins>(
-      path.join(profilePluginsDir, "installed_plugins.json"),
-      { plugins: {} },
-    );
+    const srcInstalled = await readJson<InstalledPlugins>(path.join(profilePluginsDir, "installed_plugins.json"), {
+      plugins: {},
+    });
     const dstInstalledPath = path.join(primaryPluginsDir, "installed_plugins.json");
     const dstInstalled = await readJson<InstalledPlugins>(dstInstalledPath, { version: 2, plugins: {} });
     const dstPlugins = dstInstalled.plugins ?? {};
@@ -444,7 +444,9 @@ async function mergePluginFiles(profilePluginsDir: string, primaryPluginsDir: st
         if (entry.installPath) {
           const pluginsIdx = entry.installPath.indexOf("/plugins/");
           const newInstallPath =
-            pluginsIdx !== -1 ? path.join(primaryPluginsDir, entry.installPath.slice(pluginsIdx + "/plugins/".length)) : entry.installPath;
+            pluginsIdx !== -1
+              ? path.join(primaryPluginsDir, entry.installPath.slice(pluginsIdx + "/plugins/".length))
+              : entry.installPath;
           return { ...entry, installPath: newInstallPath };
         }
         return entry;
@@ -646,7 +648,7 @@ export async function listProfiles(): Promise<ProfileListItem[]> {
 
 export async function setActiveProfileByName(name: string) {
   const registry = await loadRegistry();
-  if (!registry || !registry.profiles[name]) {
+  if (!registry?.profiles[name]) {
     throw new Error(`Profile '${name}' not found.`);
   }
 
@@ -657,7 +659,7 @@ export async function setActiveProfileByName(name: string) {
 
 export async function getCurrentProfile() {
   const registry = await loadRegistry();
-  if (!registry || !registry.activeProfile || !registry.profiles[registry.activeProfile]) {
+  if (!registry?.activeProfile || !registry.profiles[registry.activeProfile]) {
     return null;
   }
 
@@ -711,7 +713,9 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
     return [];
   }
 
-  const primaryEntries = new Set((await readdir(registry.primarySource, { withFileTypes: true })).map((entry) => entry.name));
+  const primaryEntries = new Set(
+    (await readdir(registry.primarySource, { withFileTypes: true })).map((entry) => entry.name),
+  );
   const results: DoctorProfileResult[] = [];
 
   for (const [name, profile] of Object.entries(registry.profiles)) {
@@ -736,12 +740,19 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
 
     const dirEntries = await readdir(profile.configDir, { withFileTypes: true }).catch(() => []);
     const skipSet = sharedLinkSkipSet(profile.mergeSessions ?? false);
-    const symlinkItems: Array<{ name: string; isSymlink: boolean; pointsToPrimary: boolean; targetExists: boolean; existsInPrimary: boolean }> = [];
+    const symlinkItems: Array<{
+      name: string;
+      isSymlink: boolean;
+      pointsToPrimary: boolean;
+      targetExists: boolean;
+      existsInPrimary: boolean;
+    }> = [];
     for (const entry of dirEntries) {
       const targetPath = path.join(profile.configDir, entry.name);
       const stats = await lstat(targetPath);
       const isSymlink = stats.isSymbolicLink();
-      const pointsToPrimary = isSymlink && (await readlink(targetPath)) === path.join(registry.primarySource, entry.name);
+      const pointsToPrimary =
+        isSymlink && (await readlink(targetPath)) === path.join(registry.primarySource, entry.name);
 
       if (skipSet.has(entry.name)) {
         // Items in skip set should NOT be symlinked to primary
@@ -786,16 +797,24 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
           path.join(profilePlugins, "known_marketplaces.json"),
           {},
         );
-        const marketplaceDirs = await readdir(path.join(profilePlugins, "marketplaces"), { withFileTypes: true }).catch(() => []);
+        const marketplaceDirs = await readdir(path.join(profilePlugins, "marketplaces"), { withFileTypes: true }).catch(
+          () => [],
+        );
         const onDisk = new Set(marketplaceDirs.filter((e) => e.isDirectory()).map((e) => e.name));
 
         let pluginsOutOfSync = false;
         for (const name of onDisk) {
-          if (!knownJson[name]) { pluginsOutOfSync = true; break; }
+          if (!knownJson[name]) {
+            pluginsOutOfSync = true;
+            break;
+          }
         }
         if (!pluginsOutOfSync) {
           for (const [name, entry] of Object.entries(knownJson)) {
-            if (!onDisk.has(name)) { pluginsOutOfSync = true; break; }
+            if (!onDisk.has(name)) {
+              pluginsOutOfSync = true;
+              break;
+            }
             const e = entry as Record<string, unknown>;
             if (e.installLocation !== path.join(profile.configDir, "plugins", "marketplaces", name)) {
               pluginsOutOfSync = true;
@@ -805,7 +824,10 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
         }
 
         if (pluginsOutOfSync) {
-          issues.push({ kind: "plugins_out_of_sync", message: "plugins/ marketplaces and known_marketplaces.json are out of sync" });
+          issues.push({
+            kind: "plugins_out_of_sync",
+            message: "plugins/ marketplaces and known_marketplaces.json are out of sync",
+          });
         }
       }
     }
@@ -825,7 +847,7 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
 
 export async function repairProfile(name: string) {
   const registry = await loadRegistry();
-  if (!registry || !registry.profiles[name]) {
+  if (!registry?.profiles[name]) {
     throw new Error(`Profile '${name}' not found.`);
   }
 
@@ -835,7 +857,12 @@ export async function repairProfile(name: string) {
   }
 
   const backupDir = path.join(CLAUSONA_DIR, "backups", name);
-  const repaired = await setupSharedLinks(profile.configDir, registry.primarySource, profile.mergeSessions ?? false, backupDir);
+  const repaired = await setupSharedLinks(
+    profile.configDir,
+    registry.primarySource,
+    profile.mergeSessions ?? false,
+    backupDir,
+  );
   await setupPluginsDir(profile.configDir, registry.primarySource);
 
   // Restore skip-set items from backup if they were stale symlinks that got removed
@@ -861,7 +888,7 @@ export async function repairProfile(name: string) {
 
 export async function updateProfileConfig(name: string, options: { mergeSessions: boolean }) {
   const registry = await loadRegistry();
-  if (!registry || !registry.profiles[name]) {
+  if (!registry?.profiles[name]) {
     throw new Error(`Profile '${name}' not found.`);
   }
   const profile = registry.profiles[name];
@@ -1010,7 +1037,7 @@ export async function addProfile(options: { name: string; fromPath?: string; mer
 
 export async function loginProfile(name: string) {
   const registry = await loadRegistry();
-  if (!registry || !registry.profiles[name]) {
+  if (!registry?.profiles[name]) {
     throw new Error(`Profile '${name}' not found.`);
   }
 
@@ -1059,7 +1086,7 @@ async function cleanupProfile(name: string, profile: { configDir: string; isPrim
 
 export async function removeProfile(name: string) {
   const registry = await loadRegistry();
-  if (!registry || !registry.profiles[name]) {
+  if (!registry?.profiles[name]) {
     throw new Error(`Profile '${name}' not found.`);
   }
 
@@ -1079,7 +1106,7 @@ export async function removeProfile(name: string) {
 
 export async function resolveProfileEnv(name: string): Promise<{ configDir: string; env: NodeJS.ProcessEnv }> {
   const registry = await loadRegistry();
-  if (!registry || !registry.profiles[name]) {
+  if (!registry?.profiles[name]) {
     throw new Error(`Profile '${name}' not found.`);
   }
 

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "ink-testing-library";
 import { describe, expect, it, vi } from "vitest";
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState } from "react";
 import { homedir } from "node:os";
 import path from "node:path";
+import { Spinner } from "@inkjs/ui";
 import { Box, Text, useApp, useInput, useStdout } from "ink";
 import TextInput from "ink-text-input";
-import { Spinner } from "@inkjs/ui";
+import { useEffect, useRef, useState } from "react";
 
 import { bootstrapInitFromCurrentState } from "../commands.js";
+import { formatCount, formatCurrency, localTimezoneLabel } from "../lib/format.js";
 import {
   addProfile,
   discoverAccounts,
@@ -19,14 +20,13 @@ import {
   updateProfileConfig,
   validateConfigDir,
 } from "../lib/service.js";
+import type { DiscoveredAccount, DoctorProfileResult, ProfileListItem } from "../types.js";
 import { Chrome } from "./components/Chrome.js";
+import { Divider } from "./components/Divider.js";
 import { ProfilePreview } from "./components/ProfilePreview.js";
 import { SelectList, type SelectListItem } from "./components/SelectList.js";
 import { StepIndicator } from "./components/StepIndicator.js";
-import { Divider } from "./components/Divider.js";
 import { color, symbol } from "./theme.js";
-import { formatCurrency, formatCount, localTimezoneLabel } from "../lib/format.js";
-import type { DiscoveredAccount, DoctorProfileResult, ProfileListItem } from "../types.js";
 
 type Screen = "dashboard" | "use" | "doctor" | "init" | "usage";
 type InitStep = "loading" | "select" | "name" | "default" | "review" | "applying" | "done" | "error";
@@ -51,7 +51,17 @@ type InitState = {
 
 // ── Add / Overlay types ──
 
-type AddStep = "loading" | "method" | "discover-select" | "discover-name" | "login-name" | "import-path" | "import-name" | "applying" | "done" | "error";
+type AddStep =
+  | "loading"
+  | "method"
+  | "discover-select"
+  | "discover-name"
+  | "login-name"
+  | "import-path"
+  | "import-name"
+  | "applying"
+  | "done"
+  | "error";
 
 type AddState = {
   step: AddStep;
@@ -76,12 +86,7 @@ type OverlayState =
   | { kind: "login"; profileName: string; email: string }
   | { kind: "sessions"; profileName: string; currentMerge: boolean };
 
-const INIT_STEPS = [
-  { label: "Select" },
-  { label: "Name" },
-  { label: "Default" },
-  { label: "Review" },
-];
+const INIT_STEPS = [{ label: "Select" }, { label: "Name" }, { label: "Default" }, { label: "Review" }];
 
 // ── Hint sets ──
 
@@ -102,7 +107,6 @@ const initSelectHints = [
   { keys: "enter", action: "confirm" },
   { keys: "esc", action: "back" },
 ];
-
 
 const selectHints = [
   { keys: "↑↓", action: "navigate" },
@@ -147,21 +151,21 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
   const [screen, setScreen] = useState<Screen>(initialScreen);
   // Force clear the console state to prevent output duplication on terminal resize.
   useEffect(() => {
-    if (stdout && typeof stdout.on === 'function') {
+    if (stdout && typeof stdout.on === "function") {
       let resizeTimer: NodeJS.Timeout;
       const onResize = () => {
         clearTimeout(resizeTimer);
         // Clear immediately to avoid partial layouts
-        write('\x1b[2J\x1b[3J\x1b[H'); 
+        write("\x1b[2J\x1b[3J\x1b[H");
         resizeTimer = setTimeout(() => {
           // Tell ink to re-render
-          setScreen((s) => s); 
+          setScreen((s) => s);
         }, 10);
       };
       stdout.on("resize", onResize);
-      return () => { 
+      return () => {
         clearTimeout(resizeTimer);
-        stdout.off("resize", onResize); 
+        stdout.off("resize", onResize);
       };
     }
   }, [stdout, write]);
@@ -239,9 +243,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           : null,
       );
     } catch {
-      setAddState((prev) =>
-        prev ? { ...prev, step: "method", discoveredAccounts: [], cursor: 0 } : null,
-      );
+      setAddState((prev) => (prev ? { ...prev, step: "method", discoveredAccounts: [], cursor: 0 } : null));
     }
   }
 
@@ -271,6 +273,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
     }
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount; refreshDashboard is recreated each render
   useEffect(() => {
     void refreshDashboard();
   }, []);
@@ -290,10 +293,10 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
             profileNames: state.profileNames,
             cursor: 0,
             nameIndex: 0,
-            nameDraft: firstSelected ? state.profileNames[firstSelected] ?? "" : "",
+            nameDraft: firstSelected ? (state.profileNames[firstSelected] ?? "") : "",
             defaultProfile: state.defaultProfile,
             mergeSessionsMap: {},
-    nameField: 0,
+            nameField: 0,
           });
         } catch (error) {
           setInitState({
@@ -306,7 +309,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
             nameDraft: "",
             defaultProfile: "default",
             mergeSessionsMap: {},
-    nameField: 0,
+            nameField: 0,
             message: error instanceof Error ? error.message : String(error),
           });
         }
@@ -340,7 +343,12 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
         const selectedAction = actions[cursor]?.id;
         if (selectedAction === "quit") {
           exit();
-        } else if (selectedAction === "use" || selectedAction === "doctor" || selectedAction === "init" || selectedAction === "usage") {
+        } else if (
+          selectedAction === "use" ||
+          selectedAction === "doctor" ||
+          selectedAction === "init" ||
+          selectedAction === "usage"
+        ) {
           setCursor(0);
           setScreen(selectedAction);
         }
@@ -353,12 +361,16 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
       if (screen === "use" && addState) {
         if (addState.step === "method" || addState.step === "done" || addState.step === "error") {
           resetAddState();
-        } else if (addState.step === "discover-select" || addState.step === "login-name" || addState.step === "import-path") {
-          setAddState((prev) => prev ? { ...prev, step: "method", cursor: 0 } : null);
+        } else if (
+          addState.step === "discover-select" ||
+          addState.step === "login-name" ||
+          addState.step === "import-path"
+        ) {
+          setAddState((prev) => (prev ? { ...prev, step: "method", cursor: 0 } : null));
         } else if (addState.step === "discover-name") {
-          setAddState((prev) => prev ? { ...prev, step: "discover-select", cursor: 0 } : null);
+          setAddState((prev) => (prev ? { ...prev, step: "discover-select", cursor: 0 } : null));
         } else if (addState.step === "import-name") {
-          setAddState((prev) => prev ? { ...prev, step: "import-path", importError: null } : null);
+          setAddState((prev) => (prev ? { ...prev, step: "import-path", importError: null } : null));
         } else if (addState.step === "loading" || addState.step === "applying") {
           // No-op: async 작업 완료 대기
         }
@@ -431,7 +443,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                 const newMerge = !overlay.currentMerge;
                 await updateProfileConfig(overlay.profileName, { mergeSessions: newMerge });
                 setOverlay(null);
-                setMessage(`${symbol.check} ${overlay.profileName} sessions set to ${newMerge ? "merged" : "separated"}`);
+                setMessage(
+                  `${symbol.check} ${overlay.profileName} sessions set to ${newMerge ? "merged" : "separated"}`,
+                );
                 await refreshDashboard();
               } catch (error) {
                 setOverlay(null);
@@ -449,22 +463,30 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
         if (addState.step === "method") {
           const methods = ["discover", "login", "import"] as const;
           if (key.upArrow) {
-            setAddState((prev) => prev ? { ...prev, cursor: (prev.cursor - 1 + methods.length) % methods.length } : null);
+            setAddState((prev) =>
+              prev ? { ...prev, cursor: (prev.cursor - 1 + methods.length) % methods.length } : null,
+            );
           } else if (key.downArrow) {
-            setAddState((prev) => prev ? { ...prev, cursor: (prev.cursor + 1) % methods.length } : null);
+            setAddState((prev) => (prev ? { ...prev, cursor: (prev.cursor + 1) % methods.length } : null));
           } else if (key.return) {
             const selected = methods[addState.cursor];
             if (selected === "discover") {
               if (addState.discoveredAccounts.length === 0) {
-                setAddState((prev) => prev ? { ...prev, step: "error", message: "No unregistered accounts found." } : null);
+                setAddState((prev) =>
+                  prev ? { ...prev, step: "error", message: "No unregistered accounts found." } : null,
+                );
               } else {
                 const allDirs = addState.discoveredAccounts.map((a) => a.configDir);
-                setAddState((prev) => prev ? { ...prev, step: "discover-select", selectedAccounts: allDirs, cursor: 0 } : null);
+                setAddState((prev) =>
+                  prev ? { ...prev, step: "discover-select", selectedAccounts: allDirs, cursor: 0 } : null,
+                );
               }
             } else if (selected === "login") {
-              setAddState((prev) => prev ? { ...prev, step: "login-name", nameDraft: "" } : null);
+              setAddState((prev) => (prev ? { ...prev, step: "login-name", nameDraft: "" } : null));
             } else if (selected === "import") {
-              setAddState((prev) => prev ? { ...prev, step: "import-path", importPath: "", importError: null } : null);
+              setAddState((prev) =>
+                prev ? { ...prev, step: "import-path", importPath: "", importError: null } : null,
+              );
             }
           }
           return;
@@ -474,9 +496,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
         if (addState.step === "discover-select") {
           const len = addState.discoveredAccounts.length;
           if (key.upArrow) {
-            setAddState((prev) => prev ? { ...prev, cursor: (prev.cursor - 1 + len) % Math.max(1, len) } : null);
+            setAddState((prev) => (prev ? { ...prev, cursor: (prev.cursor - 1 + len) % Math.max(1, len) } : null));
           } else if (key.downArrow) {
-            setAddState((prev) => prev ? { ...prev, cursor: (prev.cursor + 1) % Math.max(1, len) } : null);
+            setAddState((prev) => (prev ? { ...prev, cursor: (prev.cursor + 1) % Math.max(1, len) } : null));
           } else if (input === " ") {
             setAddState((prev) => {
               if (!prev) return null;
@@ -490,35 +512,52 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           } else if (key.return && addState.selectedAccounts.length > 0) {
             const first = addState.selectedAccounts[0];
             const account = addState.discoveredAccounts.find((a) => a.configDir === first);
-            const defaultName = account ? (path.basename(account.configDir).replace(/^\.claude-?/, "") || "profile") : "profile";
-            setAddState((prev) => prev ? {
-              ...prev,
-              step: "discover-name",
-              nameIndex: 0,
-              nameDraft: defaultName,
-              profileNames: {},
-            } : null);
+            const defaultName = account
+              ? path.basename(account.configDir).replace(/^\.claude-?/, "") || "profile"
+              : "profile";
+            setAddState((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    step: "discover-name",
+                    nameIndex: 0,
+                    nameDraft: defaultName,
+                    profileNames: {},
+                  }
+                : null,
+            );
           }
           return;
         }
 
         // Add name steps: up/down to switch field, space to toggle sessions
-        if ((addState.step === "discover-name" || addState.step === "login-name" || addState.step === "import-name") && (key.upArrow || key.downArrow)) {
-          setAddState((prev) => prev ? { ...prev, nameField: prev.nameField === 0 ? 1 : 0 } : null);
+        if (
+          (addState.step === "discover-name" || addState.step === "login-name" || addState.step === "import-name") &&
+          (key.upArrow || key.downArrow)
+        ) {
+          setAddState((prev) => (prev ? { ...prev, nameField: prev.nameField === 0 ? 1 : 0 } : null));
           return;
         }
 
-        if ((addState.step === "discover-name" || addState.step === "login-name" || addState.step === "import-name") && addState.nameField === 1 && input === " ") {
+        if (
+          (addState.step === "discover-name" || addState.step === "login-name" || addState.step === "import-name") &&
+          addState.nameField === 1 &&
+          input === " "
+        ) {
           if (addState.step === "discover-name") {
             const currentDir = addState.selectedAccounts[addState.nameIndex];
             if (currentDir) {
-              setAddState((prev) => prev ? {
-                ...prev,
-                mergeSessionsMap: { ...prev.mergeSessionsMap, [currentDir]: !prev.mergeSessionsMap[currentDir] },
-              } : null);
+              setAddState((prev) =>
+                prev
+                  ? {
+                      ...prev,
+                      mergeSessionsMap: { ...prev.mergeSessionsMap, [currentDir]: !prev.mergeSessionsMap[currentDir] },
+                    }
+                  : null,
+              );
             }
           } else {
-            setAddState((prev) => prev ? { ...prev, mergeSessions: !prev.mergeSessions } : null);
+            setAddState((prev) => (prev ? { ...prev, mergeSessions: !prev.mergeSessions } : null));
           }
           return;
         }
@@ -530,31 +569,50 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           const trimmed = addState.nameDraft.trim() || "profile";
           // Check for duplicate name
           if (profiles.some((p) => p.name === trimmed) || Object.values(addState.profileNames).includes(trimmed)) {
-            setAddState((prev) => prev ? { ...prev, message: `Profile "${trimmed}" already exists` } : null);
+            setAddState((prev) => (prev ? { ...prev, message: `Profile "${trimmed}" already exists` } : null));
             return;
           }
           const nextNames = { ...addState.profileNames, [currentDir]: trimmed };
           const nextIndex = addState.nameIndex + 1;
           if (nextIndex >= addState.selectedAccounts.length) {
             // Apply all
-            setAddState((prev) => prev ? { ...prev, profileNames: nextNames, step: "applying" } : null);
+            setAddState((prev) => (prev ? { ...prev, profileNames: nextNames, step: "applying" } : null));
             void (async () => {
               try {
                 for (const [dir, name] of Object.entries(nextNames)) {
                   const merge = addState.mergeSessionsMap[dir] || undefined;
                   await addProfile({ name, fromPath: dir, mergeSessions: merge });
                 }
-                setAddState((prev) => prev ? { ...prev, step: "done", message: `Added ${Object.keys(nextNames).length} profile(s)` } : null);
+                setAddState((prev) =>
+                  prev ? { ...prev, step: "done", message: `Added ${Object.keys(nextNames).length} profile(s)` } : null,
+                );
                 await refreshDashboard();
               } catch (error) {
-                setAddState((prev) => prev ? { ...prev, step: "error", message: error instanceof Error ? error.message : String(error) } : null);
+                setAddState((prev) =>
+                  prev
+                    ? { ...prev, step: "error", message: error instanceof Error ? error.message : String(error) }
+                    : null,
+                );
               }
             })();
           } else {
             const nextDir = addState.selectedAccounts[nextIndex];
             const nextAccount = addState.discoveredAccounts.find((a) => a.configDir === nextDir);
-            const nextDefault = nextAccount ? (path.basename(nextAccount.configDir).replace(/^\.claude-?/, "") || "profile") : "profile";
-            setAddState((prev) => prev ? { ...prev, profileNames: nextNames, nameIndex: nextIndex, nameField: 0, nameDraft: nextDefault, message: undefined } : null);
+            const nextDefault = nextAccount
+              ? path.basename(nextAccount.configDir).replace(/^\.claude-?/, "") || "profile"
+              : "profile";
+            setAddState((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    profileNames: nextNames,
+                    nameIndex: nextIndex,
+                    nameField: 0,
+                    nameDraft: nextDefault,
+                    message: undefined,
+                  }
+                : null,
+            );
           }
           return;
         }
@@ -564,17 +622,25 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           const name = addState.nameDraft.trim();
           if (!name) return;
           if (profiles.some((p) => p.name === name)) {
-            setAddState((prev) => prev ? { ...prev, message: `Profile "${name}" already exists` } : null);
+            setAddState((prev) => (prev ? { ...prev, message: `Profile "${name}" already exists` } : null));
             return;
           }
-          setAddState((prev) => prev ? { ...prev, step: "applying" } : null);
+          setAddState((prev) => (prev ? { ...prev, step: "applying" } : null));
           void (async () => {
             try {
-              const result = await suspendTuiAndRun(() => addProfile({ name, mergeSessions: addState.mergeSessions || undefined }));
-              setAddState((prev) => prev ? { ...prev, step: "done", message: `Added ${result.name} (${result.email})` } : null);
+              const result = await suspendTuiAndRun(() =>
+                addProfile({ name, mergeSessions: addState.mergeSessions || undefined }),
+              );
+              setAddState((prev) =>
+                prev ? { ...prev, step: "done", message: `Added ${result.name} (${result.email})` } : null,
+              );
               await refreshDashboard();
             } catch (error) {
-              setAddState((prev) => prev ? { ...prev, step: "error", message: error instanceof Error ? error.message : String(error) } : null);
+              setAddState((prev) =>
+                prev
+                  ? { ...prev, step: "error", message: error instanceof Error ? error.message : String(error) }
+                  : null,
+              );
             }
           })();
           return;
@@ -585,18 +651,25 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           const inputPath = addState.importPath.trim();
           if (!inputPath) return;
           void (async () => {
-            const result = await validateConfigDir(inputPath, profiles.map((p) => p.configDir));
+            const result = await validateConfigDir(
+              inputPath,
+              profiles.map((p) => p.configDir),
+            );
             if ("error" in result) {
-              setAddState((prev) => prev ? { ...prev, importError: result.error } : null);
+              setAddState((prev) => (prev ? { ...prev, importError: result.error } : null));
             } else {
               const defaultName = path.basename(result.account.configDir).replace(/^\.claude-?/, "") || "profile";
-              setAddState((prev) => prev ? {
-                ...prev,
-                step: "import-name",
-                importAccount: result.account,
-                nameDraft: defaultName,
-                importError: null,
-              } : null);
+              setAddState((prev) =>
+                prev
+                  ? {
+                      ...prev,
+                      step: "import-name",
+                      importAccount: result.account,
+                      nameDraft: defaultName,
+                      importError: null,
+                    }
+                  : null,
+              );
             }
           })();
           return;
@@ -607,17 +680,27 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           const name = addState.nameDraft.trim();
           if (!name || !addState.importAccount) return;
           if (profiles.some((p) => p.name === name)) {
-            setAddState((prev) => prev ? { ...prev, message: `Profile "${name}" already exists` } : null);
+            setAddState((prev) => (prev ? { ...prev, message: `Profile "${name}" already exists` } : null));
             return;
           }
-          setAddState((prev) => prev ? { ...prev, step: "applying" } : null);
+          setAddState((prev) => (prev ? { ...prev, step: "applying" } : null));
           void (async () => {
             try {
-              const result = await addProfile({ name, fromPath: addState.importAccount!.configDir, mergeSessions: addState.mergeSessions || undefined });
-              setAddState((prev) => prev ? { ...prev, step: "done", message: `Added ${result.name} (${result.email})` } : null);
+              const result = await addProfile({
+                name,
+                fromPath: addState.importAccount?.configDir,
+                mergeSessions: addState.mergeSessions || undefined,
+              });
+              setAddState((prev) =>
+                prev ? { ...prev, step: "done", message: `Added ${result.name} (${result.email})` } : null,
+              );
               await refreshDashboard();
             } catch (error) {
-              setAddState((prev) => prev ? { ...prev, step: "error", message: error instanceof Error ? error.message : String(error) } : null);
+              setAddState((prev) =>
+                prev
+                  ? { ...prev, step: "error", message: error instanceof Error ? error.message : String(error) }
+                  : null,
+              );
             }
           })();
           return;
@@ -632,7 +715,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
         // Error - press any key to go back to method
         if (addState.step === "error") {
           if (key.return || input === "r") {
-            setAddState((prev) => prev ? { ...prev, step: "method", cursor: 0, message: undefined } : null);
+            setAddState((prev) => (prev ? { ...prev, step: "method", cursor: 0, message: undefined } : null));
           }
           return;
         }
@@ -700,9 +783,11 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
             const freshDoctor = await doctorProfiles();
             setDoctor(freshDoctor);
             const fixed = freshDoctor.find((dd) => dd.name === d.name);
-            setMessage(fixed?.healthy
-              ? `${symbol.check} ${d.name} repaired — all issues resolved`
-              : `${symbol.diamond} ${d.name} repaired — ${fixed?.issues.length ?? 0} issue(s) remaining`);
+            setMessage(
+              fixed?.healthy
+                ? `${symbol.check} ${d.name} repaired — all issues resolved`
+                : `${symbol.diamond} ${d.name} repaired — ${fixed?.issues.length ?? 0} issue(s) remaining`,
+            );
           } catch (error) {
             setMessage(`${symbol.cross} ${error instanceof Error ? error.message : String(error)}`);
           }
@@ -859,7 +944,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
 
   // TUI suspended for interactive child process (e.g. OAuth login)
   if (suspended) {
-    return <></>;
+    return null;
   }
 
   // Loading
@@ -875,20 +960,25 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
   if (screen === "dashboard") {
     const activeProfile = profiles.find((p) => p.isActive) ?? profiles[0];
     return (
-      <Chrome
-        title="Dashboard"
-        footer={message || undefined}
-        hints={dashboardHints}
-      >
+      <Chrome title="Dashboard" footer={message || undefined} hints={dashboardHints}>
         <Box gap={2} flexDirection="row" width="100%">
-          <Box flexDirection="column" width="50%" minWidth={1} flexShrink={0} borderStyle="round" borderColor={color.dim} paddingX={1} paddingY={0}>
+          <Box
+            flexDirection="column"
+            width="50%"
+            minWidth={1}
+            flexShrink={0}
+            borderStyle="round"
+            borderColor={color.dim}
+            paddingX={1}
+            paddingY={0}
+          >
             <SelectList items={actions} index={cursor} />
           </Box>
           <Box flexGrow={1} flexShrink={1} minWidth={1} overflow="hidden">
             <ProfilePreview
               profile={activeProfile}
               doctor={activeProfile ? doctor.find((d) => d.name === activeProfile.name) : undefined}
-              />
+            />
           </Box>
         </Box>
       </Chrome>
@@ -917,7 +1007,13 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
 
       if (addState.step === "error") {
         return (
-          <Chrome title="Add Profile" hints={[{ keys: "r", action: "retry" }, { keys: "esc", action: "back" }]}>
+          <Chrome
+            title="Add Profile"
+            hints={[
+              { keys: "r", action: "retry" },
+              { keys: "esc", action: "back" },
+            ]}
+          >
             <Box flexDirection="column" gap={1} borderStyle="round" borderColor={color.error} paddingX={2} paddingY={1}>
               <Box gap={1}>
                 <Text color={color.error}>{symbol.cross}</Text>
@@ -931,10 +1027,19 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
       if (addState.step === "done") {
         return (
           <Chrome title="Add Profile" hints={[{ keys: "enter", action: "done" }]}>
-            <Box flexDirection="column" gap={1} borderStyle="round" borderColor={color.healthy} paddingX={2} paddingY={1}>
+            <Box
+              flexDirection="column"
+              gap={1}
+              borderStyle="round"
+              borderColor={color.healthy}
+              paddingX={2}
+              paddingY={1}
+            >
               <Box gap={1}>
                 <Text color={color.healthy}>{symbol.check}</Text>
-                <Text color={color.healthy} bold>{addState.message}</Text>
+                <Text color={color.healthy} bold>
+                  {addState.message}
+                </Text>
               </Box>
             </Box>
           </Chrome>
@@ -975,7 +1080,16 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
         return (
           <Chrome title="Add Profile" subtitle="Discover" hints={addDiscoverHints}>
             <Box gap={2} flexDirection="row" width="100%">
-              <Box flexDirection="column" width="50%" minWidth={1} flexShrink={0} borderStyle="round" borderColor={color.dim} paddingX={1} paddingY={0}>
+              <Box
+                flexDirection="column"
+                width="50%"
+                minWidth={1}
+                flexShrink={0}
+                borderStyle="round"
+                borderColor={color.dim}
+                paddingX={1}
+                paddingY={0}
+              >
                 <Text color={color.secondary}>Select accounts to register:</Text>
                 <SelectList
                   multi
@@ -988,10 +1102,21 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                   index={addState.cursor}
                 />
               </Box>
-              <Box flexGrow={1} flexShrink={1} minWidth={1} borderStyle="round" borderColor={color.dim} paddingX={1} flexDirection="column" overflow="hidden">
+              <Box
+                flexGrow={1}
+                flexShrink={1}
+                minWidth={1}
+                borderStyle="round"
+                borderColor={color.dim}
+                paddingX={1}
+                flexDirection="column"
+                overflow="hidden"
+              >
                 {currentAccount ? (
                   <>
-                    <Text color={color.text} bold>{currentAccount.configDir.replace(homedir(), "~")}</Text>
+                    <Text color={color.text} bold>
+                      {currentAccount.configDir.replace(homedir(), "~")}
+                    </Text>
                     <Text color={color.secondary}>{currentAccount.email}</Text>
                     {currentAccount.orgName && <Text color={color.muted}>{currentAccount.orgName}</Text>}
                     <Box marginTop={1} gap={1}>
@@ -1024,7 +1149,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                   <Text color={color.text}>{account?.email}</Text>
                 </Box>
                 <Box gap={1}>
-                  <Text color={color.muted}>Config  </Text>
+                  <Text color={color.muted}>Config </Text>
                   <Text color={color.secondary}>{currentDir?.replace(homedir(), "~")}</Text>
                 </Box>
               </Box>
@@ -1035,16 +1160,22 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                 </Box>
               )}
               <Box gap={1}>
-                <Text color={addState.nameField === 0 ? color.cursor : color.dim}>{addState.nameField === 0 ? symbol.cursor : " "}</Text>
+                <Text color={addState.nameField === 0 ? color.cursor : color.dim}>
+                  {addState.nameField === 0 ? symbol.cursor : " "}
+                </Text>
                 <Text color={color.text}>Name: </Text>
                 <TextInput
                   value={addState.nameDraft}
-                  onChange={(value) => setAddState((prev) => prev ? { ...prev, nameDraft: value, message: undefined } : null)}
+                  onChange={(value) =>
+                    setAddState((prev) => (prev ? { ...prev, nameDraft: value, message: undefined } : null))
+                  }
                   focus={addState.nameField === 0}
                 />
               </Box>
               <Box gap={1}>
-                <Text color={addState.nameField === 1 ? color.cursor : color.dim}>{addState.nameField === 1 ? symbol.cursor : " "}</Text>
+                <Text color={addState.nameField === 1 ? color.cursor : color.dim}>
+                  {addState.nameField === 1 ? symbol.cursor : " "}
+                </Text>
                 <Text color={color.text}>Sessions: </Text>
                 <Text color={isMerged ? color.warning : color.text}>{isMerged ? "merged" : "separated"}</Text>
                 {addState.nameField === 1 && <Text color={color.muted}> (space to toggle)</Text>}
@@ -1058,7 +1189,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
         return (
           <Chrome title="Add Profile" subtitle="Login as new account" hints={initNameHints}>
             <Box flexDirection="column" gap={1} borderStyle="round" borderColor={color.dim} paddingX={2} paddingY={1}>
-              <Text color={color.secondary}>Enter a name for the new profile. OAuth login will open in your browser.</Text>
+              <Text color={color.secondary}>
+                Enter a name for the new profile. OAuth login will open in your browser.
+              </Text>
               {addState.message && (
                 <Box gap={1}>
                   <Text color={color.error}>{symbol.cross}</Text>
@@ -1066,18 +1199,26 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                 </Box>
               )}
               <Box gap={1}>
-                <Text color={addState.nameField === 0 ? color.cursor : color.dim}>{addState.nameField === 0 ? symbol.cursor : " "}</Text>
+                <Text color={addState.nameField === 0 ? color.cursor : color.dim}>
+                  {addState.nameField === 0 ? symbol.cursor : " "}
+                </Text>
                 <Text color={color.text}>Name: </Text>
                 <TextInput
                   value={addState.nameDraft}
-                  onChange={(value) => setAddState((prev) => prev ? { ...prev, nameDraft: value, message: undefined } : null)}
+                  onChange={(value) =>
+                    setAddState((prev) => (prev ? { ...prev, nameDraft: value, message: undefined } : null))
+                  }
                   focus={addState.nameField === 0}
                 />
               </Box>
               <Box gap={1}>
-                <Text color={addState.nameField === 1 ? color.cursor : color.dim}>{addState.nameField === 1 ? symbol.cursor : " "}</Text>
+                <Text color={addState.nameField === 1 ? color.cursor : color.dim}>
+                  {addState.nameField === 1 ? symbol.cursor : " "}
+                </Text>
                 <Text color={color.text}>Sessions: </Text>
-                <Text color={addState.mergeSessions ? color.warning : color.text}>{addState.mergeSessions ? "merged" : "separated"}</Text>
+                <Text color={addState.mergeSessions ? color.warning : color.text}>
+                  {addState.mergeSessions ? "merged" : "separated"}
+                </Text>
                 {addState.nameField === 1 && <Text color={color.muted}> (space to toggle)</Text>}
               </Box>
             </Box>
@@ -1095,7 +1236,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                 <Text color={color.text}>Path: </Text>
                 <TextInput
                   value={addState.importPath}
-                  onChange={(value) => setAddState((prev) => prev ? { ...prev, importPath: value, importError: null } : null)}
+                  onChange={(value) =>
+                    setAddState((prev) => (prev ? { ...prev, importPath: value, importError: null } : null))
+                  }
                 />
               </Box>
               {addState.importError ? (
@@ -1104,7 +1247,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                   <Text color={color.error}>{addState.importError}</Text>
                 </Box>
               ) : (
-                <Text color={color.muted}>Expects a directory containing .claude.json with valid oauthAccount credentials.</Text>
+                <Text color={color.muted}>
+                  Expects a directory containing .claude.json with valid oauthAccount credentials.
+                </Text>
               )}
             </Box>
           </Chrome>
@@ -1121,7 +1266,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                   <Text color={color.text}>{addState.importAccount?.email}</Text>
                 </Box>
                 <Box gap={1}>
-                  <Text color={color.muted}>Config  </Text>
+                  <Text color={color.muted}>Config </Text>
                   <Text color={color.secondary}>{addState.importAccount?.configDir.replace(homedir(), "~")}</Text>
                 </Box>
               </Box>
@@ -1132,18 +1277,26 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                 </Box>
               )}
               <Box gap={1}>
-                <Text color={addState.nameField === 0 ? color.cursor : color.dim}>{addState.nameField === 0 ? symbol.cursor : " "}</Text>
+                <Text color={addState.nameField === 0 ? color.cursor : color.dim}>
+                  {addState.nameField === 0 ? symbol.cursor : " "}
+                </Text>
                 <Text color={color.text}>Name: </Text>
                 <TextInput
                   value={addState.nameDraft}
-                  onChange={(value) => setAddState((prev) => prev ? { ...prev, nameDraft: value, message: undefined } : null)}
+                  onChange={(value) =>
+                    setAddState((prev) => (prev ? { ...prev, nameDraft: value, message: undefined } : null))
+                  }
                   focus={addState.nameField === 0}
                 />
               </Box>
               <Box gap={1}>
-                <Text color={addState.nameField === 1 ? color.cursor : color.dim}>{addState.nameField === 1 ? symbol.cursor : " "}</Text>
+                <Text color={addState.nameField === 1 ? color.cursor : color.dim}>
+                  {addState.nameField === 1 ? symbol.cursor : " "}
+                </Text>
                 <Text color={color.text}>Sessions: </Text>
-                <Text color={addState.mergeSessions ? color.warning : color.text}>{addState.mergeSessions ? "merged" : "separated"}</Text>
+                <Text color={addState.mergeSessions ? color.warning : color.text}>
+                  {addState.mergeSessions ? "merged" : "separated"}
+                </Text>
                 {addState.nameField === 1 && <Text color={color.muted}> (space to toggle)</Text>}
               </Box>
             </Box>
@@ -1159,7 +1312,11 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
       { keys: "enter", action: "switch" },
       { keys: "a", action: "add" },
       ...(selectedProfile && !selectedProfile.isPrimary
-        ? [{ keys: "d", action: "remove" }, { keys: "l", action: "re-login" }, { keys: "s", action: "sessions" }]
+        ? [
+            { keys: "d", action: "remove" },
+            { keys: "l", action: "re-login" },
+            { keys: "s", action: "sessions" },
+          ]
         : []),
       { keys: "esc", action: "back" },
     ];
@@ -1171,38 +1328,64 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
         hints={overlay ? overlayHints : profilesHints}
       >
         <Box gap={2} flexDirection="row" width="100%">
-          <Box flexDirection="column" width="50%" minWidth={1} flexShrink={0} borderStyle="round" borderColor={color.dim} paddingX={1} paddingY={0}>
+          <Box
+            flexDirection="column"
+            width="50%"
+            minWidth={1}
+            flexShrink={0}
+            borderStyle="round"
+            borderColor={color.dim}
+            paddingX={1}
+            paddingY={0}
+          >
             <SelectList
               items={profiles.map((p) => ({
                 id: p.name,
                 label: p.name,
                 detail: p.email,
                 badge: p.isActive ? "active" : undefined,
-                badgeVariant: p.isActive ? "active" as const : undefined,
+                badgeVariant: p.isActive ? ("active" as const) : undefined,
               }))}
               index={cursor}
             />
           </Box>
-          <Box flexGrow={1} flexShrink={1} minWidth={1} borderStyle="round" borderColor={color.dim} paddingX={1} flexDirection="column" overflow="hidden">
-            <ProfilePreview
-              profile={profiles[cursor]}
-              doctor={doctor.find((d) => d.name === profiles[cursor]?.name)}
-              />
+          <Box
+            flexGrow={1}
+            flexShrink={1}
+            minWidth={1}
+            borderStyle="round"
+            borderColor={color.dim}
+            paddingX={1}
+            flexDirection="column"
+            overflow="hidden"
+          >
+            <ProfilePreview profile={profiles[cursor]} doctor={doctor.find((d) => d.name === profiles[cursor]?.name)} />
           </Box>
         </Box>
         {overlay?.kind === "remove" && (
-          <Box flexDirection="column" borderStyle="round" borderColor={overlay.isPrimary ? color.error : color.warning} paddingX={2} paddingY={1} marginTop={1}>
+          <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor={overlay.isPrimary ? color.error : color.warning}
+            paddingX={2}
+            paddingY={1}
+            marginTop={1}
+          >
             {overlay.isPrimary ? (
               <>
                 <Box gap={1}>
                   <Text color={color.error}>{symbol.cross}</Text>
                   <Text color={color.error}>Cannot remove the primary profile.</Text>
                 </Box>
-                <Text color={color.muted} dimColor>Press esc to dismiss.</Text>
+                <Text color={color.muted} dimColor>
+                  Press esc to dismiss.
+                </Text>
               </>
             ) : (
               <>
-                <Text color={color.text} bold>Remove &quot;{overlay.profileName}&quot;?</Text>
+                <Text color={color.text} bold>
+                  Remove &quot;{overlay.profileName}&quot;?
+                </Text>
                 <Text color={color.secondary}>This will unregister the profile and clean up associated files.</Text>
                 <Box marginTop={1} gap={2}>
                   <Text color={color.warning}>y confirm</Text>
@@ -1213,9 +1396,20 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           </Box>
         )}
         {overlay?.kind === "login" && (
-          <Box flexDirection="column" borderStyle="round" borderColor={color.brand} paddingX={2} paddingY={1} marginTop={1}>
-            <Text color={color.text} bold>Re-login &quot;{overlay.profileName}&quot;?</Text>
-            <Text color={color.secondary}>This will open your browser to re-authenticate the OAuth token for {overlay.email}.</Text>
+          <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor={color.brand}
+            paddingX={2}
+            paddingY={1}
+            marginTop={1}
+          >
+            <Text color={color.text} bold>
+              Re-login &quot;{overlay.profileName}&quot;?
+            </Text>
+            <Text color={color.secondary}>
+              This will open your browser to re-authenticate the OAuth token for {overlay.email}.
+            </Text>
             <Text color={color.muted}>The TUI will be suspended during login.</Text>
             <Box marginTop={1} gap={2}>
               <Text color={color.brand}>y proceed</Text>
@@ -1224,8 +1418,17 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           </Box>
         )}
         {overlay?.kind === "sessions" && (
-          <Box flexDirection="column" borderStyle="round" borderColor={color.brand} paddingX={2} paddingY={1} marginTop={1}>
-            <Text color={color.text} bold>Change sessions for &quot;{overlay.profileName}&quot;?</Text>
+          <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor={color.brand}
+            paddingX={2}
+            paddingY={1}
+            marginTop={1}
+          >
+            <Text color={color.text} bold>
+              Change sessions for &quot;{overlay.profileName}&quot;?
+            </Text>
             <Text color={color.secondary}>
               {overlay.currentMerge
                 ? "Sessions will be isolated from the primary profile."
@@ -1233,9 +1436,13 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
             </Text>
             <Box gap={1}>
               <Text color={color.muted}>Current:</Text>
-              <Text color={overlay.currentMerge ? color.warning : color.text}>{overlay.currentMerge ? "merged" : "separated"}</Text>
+              <Text color={overlay.currentMerge ? color.warning : color.text}>
+                {overlay.currentMerge ? "merged" : "separated"}
+              </Text>
               <Text color={color.muted}>{symbol.arrow}</Text>
-              <Text color={!overlay.currentMerge ? color.warning : color.text}>{overlay.currentMerge ? "separated" : "merged"}</Text>
+              <Text color={!overlay.currentMerge ? color.warning : color.text}>
+                {overlay.currentMerge ? "separated" : "merged"}
+              </Text>
             </Box>
             <Box marginTop={1} gap={2}>
               <Text color={color.brand}>y confirm</Text>
@@ -1252,34 +1459,48 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
     const currentDoctor = doctor[cursor];
     const doctorHints = [
       ...doctorHintsBase,
-      ...(currentDoctor && !currentDoctor.healthy && !currentDoctor.isPrimary
-        ? [{ keys: "r", action: "repair" }]
-        : []),
+      ...(currentDoctor && !currentDoctor.healthy && !currentDoctor.isPrimary ? [{ keys: "r", action: "repair" }] : []),
     ];
     return (
-      <Chrome
-        title="Health Check"
-        subtitle="Inspect profile integrity and symlink status"
-        hints={doctorHints}
-      >
+      <Chrome title="Health Check" subtitle="Inspect profile integrity and symlink status" hints={doctorHints}>
         <Box gap={2} flexDirection="row" width="100%">
-          <Box flexDirection="column" width="50%" minWidth={1} flexShrink={0} borderStyle="round" borderColor={color.dim} paddingX={1} paddingY={0}>
+          <Box
+            flexDirection="column"
+            width="50%"
+            minWidth={1}
+            flexShrink={0}
+            borderStyle="round"
+            borderColor={color.dim}
+            paddingX={1}
+            paddingY={0}
+          >
             <SelectList
               items={doctor.map((r) => ({
                 id: r.name,
                 label: r.name,
                 detail: r.email,
                 badge: r.healthy ? "healthy" : `${r.issues.length} issue(s)`,
-                badgeVariant: r.healthy ? "healthy" as const : "warning" as const,
+                badgeVariant: r.healthy ? ("healthy" as const) : ("warning" as const),
               }))}
               index={cursor}
             />
           </Box>
-          <Box flexGrow={1} flexShrink={1} minWidth={1} borderStyle="round" borderColor={color.dim} paddingX={1} flexDirection="column" overflow="hidden">
+          <Box
+            flexGrow={1}
+            flexShrink={1}
+            minWidth={1}
+            borderStyle="round"
+            borderColor={color.dim}
+            paddingX={1}
+            flexDirection="column"
+            overflow="hidden"
+          >
             {currentDoctor ? (
               <>
                 <Box gap={1}>
-                  <Text color={color.text} bold>{currentDoctor.name}</Text>
+                  <Text color={color.text} bold>
+                    {currentDoctor.name}
+                  </Text>
                   <Text color={currentDoctor.healthy ? color.healthy : color.warning}>
                     {currentDoctor.healthy ? symbol.check : symbol.diamond}
                   </Text>
@@ -1343,10 +1564,14 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
 
     const getData = (p: ProfileListItem) => {
       switch (usagePeriod) {
-        case "today": return p.today;
-        case "week": return p.week;
-        case "month": return p.month;
-        case "all": return p.total;
+        case "today":
+          return p.today;
+        case "week":
+          return p.week;
+        case "month":
+          return p.month;
+        case "all":
+          return p.total;
       }
     };
 
@@ -1362,11 +1587,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           {/* Period tabs */}
           <Box gap={1} flexWrap="wrap">
             {periodKeys.map((pk) => (
-              <Text
-                key={pk}
-                color={pk === usagePeriod ? color.brand : color.muted}
-                bold={pk === usagePeriod}
-              >
+              <Text key={pk} color={pk === usagePeriod ? color.brand : color.muted} bold={pk === usagePeriod}>
                 {pk === usagePeriod ? `[${periodLabels[pk]}]` : ` ${periodLabels[pk]} `}
               </Text>
             ))}
@@ -1377,10 +1598,18 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           </Box>
 
           <Box flexDirection="row" width="100%" overflow="hidden" height={1}>
-            <Box width={14} flexShrink={0}><Text color={color.muted}>PROFILE</Text></Box>
-            <Box width={14} flexShrink={0}><Text color={color.muted}>COST</Text></Box>
-            <Box width={14} flexShrink={0}><Text color={color.muted}>INPUT</Text></Box>
-            <Box width={14} flexShrink={0}><Text color={color.muted}>OUTPUT</Text></Box>
+            <Box width={14} flexShrink={0}>
+              <Text color={color.muted}>PROFILE</Text>
+            </Box>
+            <Box width={14} flexShrink={0}>
+              <Text color={color.muted}>COST</Text>
+            </Box>
+            <Box width={14} flexShrink={0}>
+              <Text color={color.muted}>INPUT</Text>
+            </Box>
+            <Box width={14} flexShrink={0}>
+              <Text color={color.muted}>OUTPUT</Text>
+            </Box>
           </Box>
           <Divider />
           {profiles.map((p) => {
@@ -1393,19 +1622,13 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                   </Text>
                 </Box>
                 <Box width={14} flexShrink={0}>
-                  <Text color={d.cost > 0 ? color.text : color.muted}>
-                    {formatCurrency(d.cost)}
-                  </Text>
+                  <Text color={d.cost > 0 ? color.text : color.muted}>{formatCurrency(d.cost)}</Text>
                 </Box>
                 <Box width={14} flexShrink={0}>
-                  <Text color={d.inputTokens > 0 ? color.text : color.muted}>
-                    {formatCount(d.inputTokens)}
-                  </Text>
+                  <Text color={d.inputTokens > 0 ? color.text : color.muted}>{formatCount(d.inputTokens)}</Text>
                 </Box>
                 <Box width={14} flexShrink={0}>
-                  <Text color={d.outputTokens > 0 ? color.text : color.muted}>
-                    {formatCount(d.outputTokens)}
-                  </Text>
+                  <Text color={d.outputTokens > 0 ? color.text : color.muted}>{formatCount(d.outputTokens)}</Text>
                 </Box>
               </Box>
             );
@@ -1442,7 +1665,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
   if (initState.step === "loading" || initState.step === "applying") {
     return (
       <Chrome title="Initialize" hints={[]}>
-        <Spinner label={initState.step === "loading" ? "Scanning for Claude accounts..." : "Writing registry and symlinks..."} />
+        <Spinner
+          label={initState.step === "loading" ? "Scanning for Claude accounts..." : "Writing registry and symlinks..."}
+        />
       </Chrome>
     );
   }
@@ -1465,7 +1690,17 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
       <Chrome title="Initialize" hints={initSelectHints}>
         <Box flexDirection="column" gap={1}>
           <StepIndicator steps={INIT_STEPS} current={0} />
-          <Box flexDirection="column" gap={1} width="50%" minWidth={1} flexShrink={0} borderStyle="round" borderColor={color.dim} paddingX={1} paddingY={0}>
+          <Box
+            flexDirection="column"
+            gap={1}
+            width="50%"
+            minWidth={1}
+            flexShrink={0}
+            borderStyle="round"
+            borderColor={color.dim}
+            paddingX={1}
+            paddingY={0}
+          >
             <Text color={color.secondary}>Select accounts to register:</Text>
             <SelectList
               multi
@@ -1488,10 +1723,7 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
     const currentConfig = initState.selected[initState.nameIndex];
     const account = initState.accounts.find((item) => item.configDir === currentConfig);
     return (
-      <Chrome
-        title="Initialize"
-        hints={account?.isPrimary ? addInputHints : initNameHints}
-      >
+      <Chrome title="Initialize" hints={account?.isPrimary ? addInputHints : initNameHints}>
         <Box flexDirection="column" gap={1}>
           <StepIndicator steps={INIT_STEPS} current={1} />
           <Box flexDirection="column" gap={1} borderStyle="round" borderColor={color.dim} paddingX={2} paddingY={1}>
@@ -1504,12 +1736,14 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                 <Text color={color.text}>{account?.email}</Text>
               </Box>
               <Box gap={1}>
-                <Text color={color.muted}>Config  </Text>
+                <Text color={color.muted}>Config </Text>
                 <Text color={color.secondary}>{currentConfig?.replace(homedir(), "~")}</Text>
               </Box>
             </Box>
             <Box gap={1}>
-              <Text color={initState.nameField === 0 ? color.cursor : color.dim}>{initState.nameField === 0 ? symbol.cursor : " "}</Text>
+              <Text color={initState.nameField === 0 ? color.cursor : color.dim}>
+                {initState.nameField === 0 ? symbol.cursor : " "}
+              </Text>
               <Text color={color.text}>Name: </Text>
               <TextInput
                 value={initState.nameDraft}
@@ -1519,7 +1753,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
             </Box>
             {!account?.isPrimary && (
               <Box gap={1}>
-                <Text color={initState.nameField === 1 ? color.cursor : color.dim}>{initState.nameField === 1 ? symbol.cursor : " "}</Text>
+                <Text color={initState.nameField === 1 ? color.cursor : color.dim}>
+                  {initState.nameField === 1 ? symbol.cursor : " "}
+                </Text>
                 <Text color={color.text}>Sessions: </Text>
                 <Text color={initState.mergeSessionsMap[currentConfig ?? ""] ? color.warning : color.text}>
                   {initState.mergeSessionsMap[currentConfig ?? ""] ? "merged" : "separated"}
@@ -1546,7 +1782,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           <StepIndicator steps={INIT_STEPS} current={2} />
           <Box flexDirection="column" gap={1} borderStyle="round" borderColor={color.dim} paddingX={2} paddingY={1}>
             <Text color={color.secondary}>Choose the default profile:</Text>
-            <Text color={color.muted} dimColor>The default profile cannot be changed later.</Text>
+            <Text color={color.muted} dimColor>
+              The default profile cannot be changed later.
+            </Text>
             <SelectList items={selectedItems} index={initState.cursor} />
           </Box>
         </Box>
@@ -1562,7 +1800,13 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
     >
       <Box flexDirection="column" gap={1}>
         <StepIndicator steps={INIT_STEPS} current={3} />
-        <Box flexDirection="column" borderStyle="round" borderColor={initState.step === "done" ? color.healthy : color.dim} paddingX={2} paddingY={1}>
+        <Box
+          flexDirection="column"
+          borderStyle="round"
+          borderColor={initState.step === "done" ? color.healthy : color.dim}
+          paddingX={2}
+          paddingY={1}
+        >
           <Text color={color.secondary}>Review before applying:</Text>
           <Box flexDirection="column" marginTop={1}>
             {initState.selected.map((configDir) => {
@@ -1577,12 +1821,11 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                     </Text>
                   </Box>
                   <Text color={color.secondary}>{account?.email}</Text>
-                  {isDefault && (
-                    <Text color={color.brandLight}> {symbol.dot} default</Text>
-                  )}
+                  {isDefault && <Text color={color.brandLight}> {symbol.dot} default</Text>}
                   {!account?.isPrimary && (
                     <Text color={color.muted}>
-                      {" "}{symbol.dot} {initState.mergeSessionsMap[configDir] ? "merged" : "separated"}
+                      {" "}
+                      {symbol.dot} {initState.mergeSessionsMap[configDir] ? "merged" : "separated"}
                     </Text>
                   )}
                 </Box>
@@ -1592,7 +1835,9 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
           {initState.step === "done" && (
             <Box gap={1} marginTop={1}>
               <Text color={color.healthy}>{symbol.check}</Text>
-              <Text color={color.healthy} bold>Profiles initialized successfully.</Text>
+              <Text color={color.healthy} bold>
+                Profiles initialized successfully.
+              </Text>
             </Box>
           )}
         </Box>

--- a/src/tui/components/Badge.tsx
+++ b/src/tui/components/Badge.tsx
@@ -4,13 +4,13 @@ import { color, symbol } from "../theme.js";
 type BadgeVariant = "active" | "healthy" | "warning" | "error" | "info" | "muted" | "primary";
 
 const variantMap: Record<BadgeVariant, { fg: string; icon: string }> = {
-  active:  { fg: color.brand,   icon: symbol.dot },
+  active: { fg: color.brand, icon: symbol.dot },
   healthy: { fg: color.healthy, icon: symbol.check },
   warning: { fg: color.warning, icon: symbol.diamond },
-  error:   { fg: color.error,   icon: symbol.cross },
-  info:    { fg: color.info,    icon: symbol.dot },
-  muted:   { fg: color.muted,   icon: symbol.circle },
-  primary: { fg: color.accent,  icon: symbol.diamond },
+  error: { fg: color.error, icon: symbol.cross },
+  info: { fg: color.info, icon: symbol.dot },
+  muted: { fg: color.muted, icon: symbol.circle },
+  primary: { fg: color.accent, icon: symbol.diamond },
 };
 
 export function Badge({ label, variant = "muted" }: { label: string; variant?: BadgeVariant }) {

--- a/src/tui/components/Chrome.tsx
+++ b/src/tui/components/Chrome.tsx
@@ -1,5 +1,5 @@
-import { type PropsWithChildren } from "react";
 import { Box, Text } from "ink";
+import type { PropsWithChildren } from "react";
 import { color, symbol } from "../theme.js";
 import { KeyHints } from "./KeyHint.js";
 
@@ -12,7 +12,7 @@ type ChromeProps = PropsWithChildren<{
   hints?: KeyHint[];
 }>;
 
-// Use fixed long width that flex container shrinks down gracefully 
+// Use fixed long width that flex container shrinks down gracefully
 // to prevent ink size recalculation bugs and nested redraws on resize
 export function Chrome({ title, subtitle, footer, hints, children }: ChromeProps) {
   const lineWidth = 150;
@@ -23,24 +23,35 @@ export function Chrome({ title, subtitle, footer, hints, children }: ChromeProps
       <Box flexDirection="column" marginBottom={1}>
         <Box gap={1} alignItems="center" width="100%">
           <Box backgroundColor={color.brand} paddingX={1} flexShrink={0}>
-            <Text color="#ffffff" bold> CLAUSONA </Text>
+            <Text color="#ffffff" bold>
+              {" "}
+              CLAUSONA{" "}
+            </Text>
           </Box>
-          <Box flexShrink={0}><Text color={color.dim}>{symbol.sep}</Text></Box>
-          <Box flexShrink={0}><Text color={color.text} bold>{title}</Text></Box>
+          <Box flexShrink={0}>
+            <Text color={color.dim}>{symbol.sep}</Text>
+          </Box>
+          <Box flexShrink={0}>
+            <Text color={color.text} bold>
+              {title}
+            </Text>
+          </Box>
           {subtitle ? (
             <>
-              <Box flexShrink={0}><Text color={color.dim}>{symbol.sep}</Text></Box>
+              <Box flexShrink={0}>
+                <Text color={color.dim}>{symbol.sep}</Text>
+              </Box>
               <Box flexGrow={1} flexShrink={1} overflow="hidden">
-                <Text color={color.secondary} wrap="truncate-end">{subtitle}</Text>
+                <Text color={color.secondary} wrap="truncate-end">
+                  {subtitle}
+                </Text>
               </Box>
             </>
           ) : null}
         </Box>
         <Box marginTop={1} width="100%" flexDirection="row" overflow="hidden" height={1}>
           <Box flexGrow={1} flexShrink={1} minWidth={1}>
-            <Text color={color.dim}>
-              {symbol.lineH.repeat(lineWidth)}
-            </Text>
+            <Text color={color.dim}>{symbol.lineH.repeat(lineWidth)}</Text>
           </Box>
         </Box>
       </Box>
@@ -55,14 +66,14 @@ export function Chrome({ title, subtitle, footer, hints, children }: ChromeProps
         <Box marginTop={1} flexDirection="column">
           <Box flexDirection="row" width="100%" overflow="hidden" height={1}>
             <Box flexGrow={1} flexShrink={1} minWidth={1}>
-              <Text color={color.dim}>
-                {symbol.lineH.repeat(lineWidth)}
-              </Text>
+              <Text color={color.dim}>{symbol.lineH.repeat(lineWidth)}</Text>
             </Box>
           </Box>
           {footer ? (
             <Box marginTop={1}>
-              <Text color={color.muted} wrap="truncate-end">{footer}</Text>
+              <Text color={color.muted} wrap="truncate-end">
+                {footer}
+              </Text>
             </Box>
           ) : null}
           {hints && hints.length > 0 ? (

--- a/src/tui/components/Divider.tsx
+++ b/src/tui/components/Divider.tsx
@@ -7,20 +7,18 @@ export function Divider({ title, cols }: { title?: string; cols?: number }) {
 
   if (!title) {
     return (
-    <Box width="100%" flexDirection="row" overflow="hidden" height={1}>
-      <Box flexGrow={1} flexShrink={1} minWidth={1}>
-        <Text color={color.dim}>{symbol.lineH.repeat(w)}</Text>
+      <Box width="100%" flexDirection="row" overflow="hidden" height={1}>
+        <Box flexGrow={1} flexShrink={1} minWidth={1}>
+          <Text color={color.dim}>{symbol.lineH.repeat(w)}</Text>
+        </Box>
       </Box>
-    </Box>
     );
   }
 
   return (
     <Box width="100%" flexDirection="row" alignItems="center" overflow="hidden" height={1}>
       <Box flexGrow={1} flexShrink={1} minWidth={1}>
-        <Text color={color.dim}>
-          {symbol.lineH.repeat(w)}
-        </Text>
+        <Text color={color.dim}>{symbol.lineH.repeat(w)}</Text>
       </Box>
       <Box paddingX={1} flexShrink={0}>
         <Text color={color.secondary} bold wrap="truncate-end">
@@ -28,9 +26,7 @@ export function Divider({ title, cols }: { title?: string; cols?: number }) {
         </Text>
       </Box>
       <Box flexGrow={1} flexShrink={1} minWidth={1}>
-        <Text color={color.dim}>
-          {symbol.lineH.repeat(w)}
-        </Text>
+        <Text color={color.dim}>{symbol.lineH.repeat(w)}</Text>
       </Box>
     </Box>
   );

--- a/src/tui/components/KeyHint.tsx
+++ b/src/tui/components/KeyHint.tsx
@@ -9,7 +9,9 @@ export function KeyHints({ hints }: { hints: Hint[] }) {
       {hints.map((hint, i) => (
         <Box key={hint.keys}>
           {i > 0 && <Text color={color.dim}>{symbol.sep} </Text>}
-          <Text color={color.muted} bold>{hint.keys}</Text>
+          <Text color={color.muted} bold>
+            {hint.keys}
+          </Text>
           <Text color={color.dim}> {hint.action}</Text>
         </Box>
       ))}

--- a/src/tui/components/ProfilePreview.tsx
+++ b/src/tui/components/ProfilePreview.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from "ink";
-import { color, symbol } from "../theme.js";
 import { formatCurrency, localTimezoneLabel } from "../../lib/format.js";
 import type { DoctorProfileResult, ProfileListItem } from "../../types.js";
+import { color, symbol } from "../theme.js";
 
 function Row({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) {
   return (
@@ -26,13 +26,7 @@ function Separator() {
   );
 }
 
-export function ProfilePreview({
-  profile,
-  doctor,
-}: {
-  profile?: ProfileListItem;
-  doctor?: DoctorProfileResult;
-}) {
+export function ProfilePreview({ profile, doctor }: { profile?: ProfileListItem; doctor?: DoctorProfileResult }) {
   if (!profile) {
     return (
       <Box
@@ -49,11 +43,7 @@ export function ProfilePreview({
     );
   }
 
-  const healthColor = doctor
-    ? doctor.healthy
-      ? color.healthy
-      : color.warning
-    : color.muted;
+  const healthColor = doctor ? (doctor.healthy ? color.healthy : color.warning) : color.muted;
 
   const healthLabel = doctor
     ? doctor.healthy
@@ -73,10 +63,14 @@ export function ProfilePreview({
     >
       {/* Header */}
       <Box gap={1} marginBottom={1} justifyContent="space-between" flexShrink={0}>
-        <Text color={color.text} bold wrap="truncate-end">{profile.name}</Text>
+        <Text color={color.text} bold wrap="truncate-end">
+          {profile.name}
+        </Text>
         {profile.isActive && (
           <Box backgroundColor={color.brand} paddingX={1} flexShrink={0}>
-            <Text color="#ffffff" bold>ACTIVE</Text>
+            <Text color="#ffffff" bold>
+              ACTIVE
+            </Text>
           </Box>
         )}
       </Box>
@@ -87,7 +81,11 @@ export function ProfilePreview({
         {profile.orgName && <Row label="Org" value={profile.orgName} />}
         <Row label="Config" value={profile.configDir.replace(/^\/Users\/[^/]+/, "~")} valueColor={color.muted} />
         {!profile.isPrimary && (
-          <Row label="Sessions" value={profile.mergeSessions ? "merged" : "separated"} valueColor={profile.mergeSessions ? color.warning : color.secondary} />
+          <Row
+            label="Sessions"
+            value={profile.mergeSessions ? "merged" : "separated"}
+            valueColor={profile.mergeSessions ? color.warning : color.secondary}
+          />
         )}
       </Box>
 
@@ -98,14 +96,26 @@ export function ProfilePreview({
         <Box gap={1}>
           <Text color={color.dim}>{localTimezoneLabel()}</Text>
         </Box>
-        <Row label="Today" value={formatCurrency(profile.today.cost)} valueColor={profile.today.cost > 0 ? color.text : color.muted} />
-        <Row label="This Week" value={formatCurrency(profile.week.cost)} valueColor={profile.week.cost > 0 ? color.text : color.muted} />
-        <Row label="Total" value={formatCurrency(profile.total.cost)} valueColor={profile.total.cost > 0 ? color.brandLight : color.muted} />
+        <Row
+          label="Today"
+          value={formatCurrency(profile.today.cost)}
+          valueColor={profile.today.cost > 0 ? color.text : color.muted}
+        />
+        <Row
+          label="This Week"
+          value={formatCurrency(profile.week.cost)}
+          valueColor={profile.week.cost > 0 ? color.text : color.muted}
+        />
+        <Row
+          label="Total"
+          value={formatCurrency(profile.total.cost)}
+          valueColor={profile.total.cost > 0 ? color.brandLight : color.muted}
+        />
       </Box>
 
       {/* Health */}
       {doctor && (
-      <Box flexDirection="column" flexShrink={0}>
+        <Box flexDirection="column" flexShrink={0}>
           <Separator />
           <Row label="Health" value={healthLabel} valueColor={healthColor} />
           {doctor.issues.map((issue) => (

--- a/src/tui/components/SelectList.tsx
+++ b/src/tui/components/SelectList.tsx
@@ -37,9 +37,7 @@ export function SelectList({
           <Box key={item.id} gap={1}>
             {/* Cursor */}
             <Box width={2}>
-              <Text color={focused ? color.cursor : color.dim}>
-                {focused ? symbol.cursor : " "}
-              </Text>
+              <Text color={focused ? color.cursor : color.dim}>{focused ? symbol.cursor : " "}</Text>
             </Box>
 
             {/* Checkbox for multi */}

--- a/src/tui/components/StepIndicator.tsx
+++ b/src/tui/components/StepIndicator.tsx
@@ -3,35 +3,25 @@ import { color, symbol } from "../theme.js";
 
 type Step = { label: string };
 
-export function StepIndicator({
-  steps,
-  current,
-}: {
-  steps: Step[];
-  current: number;
-}) {
+export function StepIndicator({ steps, current }: { steps: Step[]; current: number }) {
   return (
     <Box gap={1}>
       {steps.map((step, i) => {
         const isDone = i < current;
         const isActive = i === current;
-        const stepColor = isDone
-          ? color.healthy
-          : isActive
-            ? color.brand
-            : color.dim;
+        const stepColor = isDone ? color.healthy : isActive ? color.brand : color.dim;
         const icon = isDone ? symbol.check : isActive ? symbol.cursor : symbol.circle;
 
         return (
           <Box key={step.label}>
-            <Text color={stepColor}>
-              {icon}
-            </Text>
-            <Text color={isActive ? color.text : isDone ? color.secondary : color.muted}>
-              {" "}{step.label}
-            </Text>
+            <Text color={stepColor}>{icon}</Text>
+            <Text color={isActive ? color.text : isDone ? color.secondary : color.muted}> {step.label}</Text>
             {i < steps.length - 1 && (
-              <Text color={color.dim}> {symbol.lineH}{symbol.lineH} </Text>
+              <Text color={color.dim}>
+                {" "}
+                {symbol.lineH}
+                {symbol.lineH}{" "}
+              </Text>
             )}
           </Box>
         );

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -4,27 +4,27 @@
 
 export const color = {
   // Core palette
-  brand: "#6366f1",       // indigo-500  — primary brand (backgrounds/accents)
-  brandLight: "#818cf8",  // indigo-400  — primary text highlights
-  accent: "#ec4899",      // pink-500    — secondary accent (cursors)
-  surface: "#18181b",     // zinc-900    — panel backgrounds
+  brand: "#6366f1", // indigo-500  — primary brand (backgrounds/accents)
+  brandLight: "#818cf8", // indigo-400  — primary text highlights
+  accent: "#ec4899", // pink-500    — secondary accent (cursors)
+  surface: "#18181b", // zinc-900    — panel backgrounds
 
   // Text hierarchy
-  text: "#f4f4f5",        // zinc-100  — primary text
-  secondary: "#a1a1aa",   // zinc-400  — secondary text
-  muted: "#71717a",       // zinc-500  — tertiary / dimmed
-  dim: "#3f3f46",         // zinc-700  — borders, separators
+  text: "#f4f4f5", // zinc-100  — primary text
+  secondary: "#a1a1aa", // zinc-400  — secondary text
+  muted: "#71717a", // zinc-500  — tertiary / dimmed
+  dim: "#3f3f46", // zinc-700  — borders, separators
 
   // Semantic status
-  healthy: "#10b981",     // emerald-500
-  warning: "#f59e0b",     // amber-500
-  error: "#ef4444",       // red-500
-  info: "#3b82f6",        // blue-500
+  healthy: "#10b981", // emerald-500
+  warning: "#f59e0b", // amber-500
+  error: "#ef4444", // red-500
+  info: "#3b82f6", // blue-500
 
   // Interactive
-  active: "#818cf8",      // matches brandLight
-  cursor: "#ec4899",      // pink-500
-  selected: "#818cf8",    // indigo-400
+  active: "#818cf8", // matches brandLight
+  cursor: "#ec4899", // pink-500
+  selected: "#818cf8", // indigo-400
 } as const;
 
 export const symbol = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,14 @@ export type ProfileListItem = {
 };
 
 export type DoctorIssue = {
-  kind: "missing_json" | "missing_oauth" | "missing_keychain" | "broken_symlink" | "local_override" | "stale_symlink" | "plugins_out_of_sync";
+  kind:
+    | "missing_json"
+    | "missing_oauth"
+    | "missing_keychain"
+    | "broken_symlink"
+    | "local_override"
+    | "stale_symlink"
+    | "plugins_out_of_sync";
   message: string;
 };
 


### PR DESCRIPTION
## Summary

Previously the only CI step was the release workflow, which ran `pnpm test` *only* when a `v*` tag was pushed. PRs and pushes to `main` had no automated validation.

This PR:
- Adds **Biome** (`@biomejs/biome@2.4.13`) as the formatter + linter (recommended ruleset). Configured for 2-space indent, double quotes, semicolons, trailing commas, line width 120 — matches existing code style. `noExplicitAny` is relaxed for `*.test.{ts,tsx}` files.
- Adds **`.github/workflows/ci.yml`** that runs `lint` → `typecheck` → `test` on every PR and push to `main`.
- Applies Biome auto-fixes across the codebase (formatting, organize imports, `useTemplate`, `useOptionalChain`, `useIndexOf`, etc.) plus a few targeted manual fixes:
  - Removed unused `clear` from two `render(...)` destructures in `src/index.tsx`
  - Replaced `<></>` with `null` in `src/tui/App.tsx` (suspended branch)
  - Hoisted a misplaced `import { realpathSync }` to the top of `src/index.tsx` and replaced `process.argv[1]!` with a guarded check
  - Refactored `??=` chained assignment in `src/core/track-usage.ts` to two lines
  - Added a `biome-ignore` for the `useEffect` whose callback is intentionally recreated every render (`refreshDashboard`) and one for the ANSI-stripping regex that legitimately uses `\x1b`

The diff is large in line count but most of it is whitespace / line-wrapping from the formatter.

## Test plan
- [x] `pnpm lint` clean (0 errors, 0 warnings)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 20/20 pass
- [x] Once merged, future PRs will be gated by these checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)