### PR TITLE
feat: show per-account plan quota (session / weekly limits) in list and TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ No re-login. No reinstalling plugins. Just switch and go.
 - **Shared environment** — MCP servers, plugins, permissions, settings (Claude) and config.toml, skills, hooks (Codex) are symlinked across profiles within each tool. Set up once, use everywhere.
 - **Pure CLI passthrough** — no wrapping, no proxying, no background process. `claude` and `codex` run directly and unmodified. Compatible with oh-my-claudecode, Cline, codex plugins, and any other tool in your stack.
 - **Lightweight** — a single shell hook and a few symlinks. No daemon, no server, no runtime overhead.
+- **Plan quota at a glance** — session and weekly limit usage for every account, read live from each tool's own usage endpoint (Claude and Codex)
 - **Usage tracking** — per-profile cost and token usage, tracked locally (Claude only in v0.1)
 - **Interactive dashboard** — TUI for managing profiles, viewing usage, and running health checks
 
@@ -53,9 +54,69 @@ clausona use work         # switch to a profile (bare name if unique)
 clausona use claude:work  # switch claude account (use prefix when both tools have "work")
 clausona add codex:work   # add a codex profile
 clausona use codex:personal  # switch codex account
-clausona list             # see all profiles with weekly usage
+clausona list             # see all profiles with plan quota and weekly usage
 clausona                  # open the interactive dashboard
 ```
+
+## Plan quota
+
+`clausona list` and the dashboard show how much of each account's plan limits are
+already spent, so you can pick a profile that still has headroom.
+
+```
+PROFILE             ACCOUNT                      5H     7D
+claude:work         you@example.com              6%     46%
+claude:personal     you@personal.com             0%     100%
+codex:work          you@example.com              —      12%
+```
+
+`5H` is the rolling session window, `7D` the weekly one. The dashboard additionally
+shows the reset time and the most-consumed per-model limit.
+
+Readings come from each tool's own usage endpoint, authenticated with the credential
+that tool already stored for that profile — clausona never asks for or stores a token
+of its own. Results are cached for 5 minutes; `--refresh` forces a re-read and
+`--no-quota` skips the network entirely.
+
+### Profiles you have not used recently
+
+An access token lasts 8 hours, so a profile you have not touched today would otherwise
+show nothing. clausona renews it on demand using the stored refresh token, which lasts
+about 14 days — so every account you have used in the last two weeks reports its quota,
+whether or not you have switched to it lately.
+
+Renewal is lazy: a token is only renewed once it has actually lapsed (or if the endpoint
+rejects it), never pre-emptively, so each profile rotates at most once per 8 hours.
+`--no-renew` turns it off.
+
+Two details make this safe to do on your behalf, and both are worth knowing if you touch
+this code:
+
+- **The refresh token rotates with no grace period.** The moment the provider answers,
+  the previous refresh token is rejected. The renewed credential is therefore written
+  and read back before the call returns; a write that cannot be verified is an error,
+  never a silent fallback.
+- **Renewal is locked per profile**, so two clausona processes cannot both rotate the
+  same credential and leave one of them holding a token the provider has already
+  invalidated.
+
+Claude credentials stay in the macOS Keychain (or `.credentials.json` elsewhere) and
+Codex credentials in `auth.json`, in place — unrelated contents of those stores, such as
+Claude's `mcpOAuth` block, are preserved.
+
+### When a reading is unavailable
+
+A dash means the reading could not be taken, and the reason is printed below the table:
+
+| State | Meaning |
+| --- | --- |
+| `expired` | The sign-in has lapsed past renewal (refresh token older than ~14 days, or revoked). Run `clausona login <profile>`. |
+| `missing` | No credential is stored for the profile. Run `clausona login <profile>`. |
+| `cooldown` | The endpoint returned 429. clausona pauses that tool until the window lifts. |
+| `error` | Network failure, timeout, or an unreadable response. |
+
+Where numbers are already known, they stay on screen dimmed with their age, rather than
+being blanked out.
 
 ## Commands
 
@@ -69,7 +130,7 @@ clausona                  # open the interactive dashboard
 | `clausona remove <profile>` | Remove a profile |
 | `clausona use [profile]` | Switch active profile |
 | `clausona run <profile> [-- args...]` | Run the tool's CLI with a specific profile |
-| `clausona list [--json]` | List all profiles with usage |
+| `clausona list [--json] [--refresh] [--no-quota] [--no-renew]` | List all profiles with plan quota and usage |
 | `clausona usage [profile] [--period=today\|week\|month\|all]` | View cost and token usage |
 | `clausona current [--json]` | Show active profile |
 | `clausona config <profile> --merge-sessions \| --separate-sessions` | Configure session mode |
@@ -135,12 +196,20 @@ The private set is larger for codex (state DB, input history, logs) but the prin
 
 ### Data Storage
 
-All data stays local on your machine.
+All data stays local on your machine. clausona has no telemetry and no server of its
+own, and nothing is sent to a third party.
+
+The one thing that leaves your machine is the plan-quota lookup: each profile's own
+credential is sent to that profile's own provider endpoint (`api.anthropic.com` for
+Claude, `chatgpt.com` for Codex) to read its limits, and to renew a lapsed token.
+Nothing else is transmitted, and `clausona list --no-quota` skips it entirely.
 
 ```
 ~/.clausona/
 ├── profiles.json    # registered profiles and active selection
 ├── usage.json       # per-profile usage history
+├── quota.json       # cached plan-quota readings (5-minute freshness)
+├── locks/           # short-lived per-profile credential renewal locks
 └── backups/
     ├── claude/      # backups of imported claude profile directories
     └── codex/       # backups of imported codex profile directories

--- a/README.md
+++ b/README.md
@@ -64,14 +64,19 @@ clausona                  # open the interactive dashboard
 already spent, so you can pick a profile that still has headroom.
 
 ```
-PROFILE             ACCOUNT                      5H     7D
-claude:work         you@example.com              6%     46%
-claude:personal     you@personal.com             0%     100%
-codex:work          you@example.com              —      12%
+PROFILE             ACCOUNT                      5H         7D
+claude:work         you@example.com              6% 23m     46% 13h
+claude:personal     you@personal.com             0%         100% 4d
+codex:work          you@example.com              —          12% 5d
 ```
 
-`5H` is the rolling session window, `7D` the weekly one. The dashboard additionally
-shows the reset time and the most-consumed per-model limit.
+`5H` is the rolling session window, `7D` the weekly one, each followed by how long
+until it resets. The dashboard shows the same reading with a gauge and the precise
+reset time, plus the most-consumed per-model limit.
+
+The table adapts to the terminal: as it narrows, token counts give way first, then
+cost, then the reset times — the quota columns and the profile name are the last things
+to go, so the row never wraps into itself.
 
 Readings come from each tool's own usage endpoint, authenticated with the credential
 that tool already stored for that profile — clausona never asks for or stores a token

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,7 +36,7 @@ const commandFlags: Record<string, { flags: string[]; prefixes?: string[] }> = {
   init: { flags: ["--auto", "--merge-sessions"] },
   add: { flags: ["--from", "--merge-sessions"] },
   use: { flags: [] },
-  list: { flags: ["--json"] },
+  list: { flags: ["--json", "--no-quota", "--no-renew", "--refresh"] },
   usage: { flags: ["--json"], prefixes: ["--period="] },
   current: { flags: ["--json"] },
   doctor: { flags: ["--json"] },
@@ -114,13 +114,16 @@ function subcommandHelpText(command: string): string | undefined {
     case "list":
       return [
         "",
-        `  ${accent("clausona list")} ${dim("— Show profiles with usage")}`,
+        `  ${accent("clausona list")} ${dim("— Show profiles with quota and usage")}`,
         "",
         `  ${bold("USAGE")}`,
-        helpUsage("clausona list [--json]"),
+        helpUsage("clausona list [--json] [--refresh] [--no-quota] [--no-renew]"),
         "",
         `  ${bold("OPTIONS")}`,
-        `    ${accent("--json".padEnd(12))}${dim("Output as JSON")}`,
+        `    ${accent("--json".padEnd(14))}${dim("Output as JSON")}`,
+        `    ${accent("--refresh".padEnd(14))}${dim("Bypass the 5-minute quota cache")}`,
+        `    ${accent("--no-quota".padEnd(14))}${dim("Skip the plan-quota lookup (no network access)")}`,
+        `    ${accent("--no-renew".padEnd(14))}${dim("Never renew a lapsed token; report it as expired")}`,
         "",
       ].join("\n");
 
@@ -296,7 +299,7 @@ function usageText() {
       ["init", "Discover accounts interactively"],
       ["add <profile>", "Add a new profile"],
       ["use [profile]", "Switch active profile"],
-      ["list", "Show profiles with usage"],
+      ["list", "Show profiles with quota and usage"],
       ["usage [profile]", "Show usage summary"],
       ["current", "Show active profile details"],
       ["config <profile>", "Configure profile settings"],
@@ -339,7 +342,11 @@ export async function runCommand(command: string, args: string[]) {
       return shellInit();
 
     case "list": {
-      const items = await listProfiles();
+      const items = await listProfiles({
+        quota: !args.includes("--no-quota"),
+        refresh: args.includes("--refresh"),
+        renew: !args.includes("--no-renew"),
+      });
       return jsonFlag(args) ? JSON.stringify(items, null, 2) : renderList(items);
     }
 

--- a/src/core/quota-store.test.ts
+++ b/src/core/quota-store.test.ts
@@ -1,0 +1,328 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import type { ToolAdapter, ToolCredential } from "../tools/types.js";
+import type { QuotaSnapshot } from "../types.js";
+import { QuotaHttpError } from "./quota.js";
+
+const getAdapter = vi.hoisted(() => vi.fn());
+vi.mock("../tools/registry.js", () => ({ getAdapter }));
+
+const { collectQuotas } = await import("./quota-store.js");
+
+const NOW = 1_800_000_000_000;
+const TARGET = { id: "claude:work", tool: "claude" as const, configDir: "/tmp/.claude-work" };
+
+let tmp: string;
+let cachePath: string;
+
+function seedCache(contents: unknown) {
+  writeFileSync(cachePath, JSON.stringify(contents), "utf8");
+}
+
+function readCacheFile() {
+  return JSON.parse(readFileSync(cachePath, "utf8"));
+}
+
+/** A stand-in adapter whose credential and fetch behaviour each test decides. */
+function stubAdapter(overrides: Partial<ToolAdapter> = {}) {
+  const adapter = {
+    readCredential: vi.fn(async (): Promise<ToolCredential | null> => ({ accessToken: "t", refreshToken: "r" })),
+    fetchQuota: vi.fn(async () => ({ session: { usedPercent: 5, resetsAt: null } })),
+    ...overrides,
+  } as unknown as ToolAdapter;
+  getAdapter.mockReturnValue(adapter);
+  return adapter;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmp = mkdtempSync(path.join(tmpdir(), "clausona-quota-"));
+  cachePath = path.join(tmp, "quota.json");
+  return () => rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("collectQuotas", () => {
+  it("fetches and caches when there is nothing on disk", async () => {
+    const adapter = stubAdapter();
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.fetchQuota).toHaveBeenCalledTimes(1);
+    expect(result[TARGET.id]).toMatchObject({ state: "ok", session: { usedPercent: 5 } });
+    expect(readCacheFile().profiles[TARGET.id].state).toBe("ok");
+  });
+
+  it("serves a recent snapshot without touching the network", async () => {
+    const adapter = stubAdapter();
+    seedCache({
+      version: 1,
+      cooldowns: {},
+      profiles: { [TARGET.id]: { state: "ok", fetchedAt: NOW - 60_000, weekly: { usedPercent: 42, resetsAt: null } } },
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.fetchQuota).not.toHaveBeenCalled();
+    expect(result[TARGET.id]?.weekly?.usedPercent).toBe(42);
+  });
+
+  it("re-fetches a recent snapshot when refresh is requested", async () => {
+    const adapter = stubAdapter();
+    seedCache({
+      version: 1,
+      cooldowns: {},
+      profiles: { [TARGET.id]: { state: "ok", fetchedAt: NOW - 60_000, weekly: { usedPercent: 42, resetsAt: null } } },
+    });
+
+    await collectQuotas([TARGET], { now: NOW, cachePath, refresh: true });
+
+    expect(adapter.fetchQuota).toHaveBeenCalledTimes(1);
+  });
+
+  it("never calls the endpoint without a credential", async () => {
+    const adapter = stubAdapter({ readCredential: vi.fn(async () => null) });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.fetchQuota).not.toHaveBeenCalled();
+    expect(result[TARGET.id]?.state).toBe("missing");
+  });
+
+  it("renews a lapsed credential instead of giving up on it", async () => {
+    const adapter = stubAdapter({
+      readCredential: vi.fn(async () => ({ accessToken: "old", refreshToken: "r", expiresAt: NOW - 1 })),
+      renewCredential: vi.fn(async () => ({ accessToken: "new", refreshToken: "r2", expiresAt: NOW + 8 * 3600_000 })),
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.renewCredential).toHaveBeenCalledTimes(1);
+    expect(adapter.fetchQuota).toHaveBeenCalledTimes(1);
+    // The renewed credential, not the lapsed one, is what reaches the endpoint.
+    expect((adapter.fetchQuota as Mock).mock.calls[0][0]).toMatchObject({ accessToken: "new" });
+    expect(result[TARGET.id]?.state).toBe("ok");
+  });
+
+  it("reports expired when renewal fails", async () => {
+    const adapter = stubAdapter({
+      readCredential: vi.fn(async () => ({ accessToken: "old", refreshToken: "r", expiresAt: NOW - 1 })),
+      renewCredential: vi.fn(async () => {
+        throw new QuotaHttpError(400);
+      }),
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.fetchQuota).not.toHaveBeenCalled();
+    expect(result[TARGET.id]?.state).toBe("expired");
+  });
+
+  it("does not renew a credential with no refresh token", async () => {
+    const adapter = stubAdapter({
+      readCredential: vi.fn(async () => ({ accessToken: "old", expiresAt: NOW - 1 })),
+      renewCredential: vi.fn(async () => ({ accessToken: "new" })),
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.renewCredential).not.toHaveBeenCalled();
+    expect(result[TARGET.id]?.state).toBe("expired");
+  });
+
+  it("leaves a lapsed credential alone when renewal is disabled", async () => {
+    const adapter = stubAdapter({
+      readCredential: vi.fn(async () => ({ accessToken: "old", refreshToken: "r", expiresAt: NOW - 1 })),
+      renewCredential: vi.fn(async () => ({ accessToken: "new" })),
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath, renew: false });
+
+    expect(adapter.renewCredential).not.toHaveBeenCalled();
+    expect(result[TARGET.id]?.state).toBe("expired");
+  });
+
+  it("renews once on a 401 from a credential that still looked valid", async () => {
+    const fetchQuota = vi
+      .fn()
+      .mockRejectedValueOnce(new QuotaHttpError(401))
+      .mockResolvedValueOnce({ session: { usedPercent: 5, resetsAt: null } });
+    const adapter = stubAdapter({
+      readCredential: vi.fn(async () => ({ accessToken: "old", refreshToken: "r", expiresAt: NOW + 3600_000 })),
+      renewCredential: vi.fn(async () => ({ accessToken: "new", refreshToken: "r2" })),
+      fetchQuota,
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.renewCredential).toHaveBeenCalledTimes(1);
+    expect(fetchQuota).toHaveBeenCalledTimes(2);
+    expect(result[TARGET.id]?.state).toBe("ok");
+  });
+
+  it("renews at most once, so a still-rejected token cannot spin", async () => {
+    const fetchQuota = vi.fn().mockRejectedValue(new QuotaHttpError(401));
+    const adapter = stubAdapter({
+      readCredential: vi.fn(async () => ({ accessToken: "old", refreshToken: "r", expiresAt: NOW + 3600_000 })),
+      renewCredential: vi.fn(async () => ({ accessToken: "new", refreshToken: "r2" })),
+      fetchQuota,
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.renewCredential).toHaveBeenCalledTimes(1);
+    expect(fetchQuota).toHaveBeenCalledTimes(2);
+    expect(result[TARGET.id]?.state).toBe("expired");
+  });
+
+  it("maps a 401 to expired but keeps the last known numbers", async () => {
+    stubAdapter({
+      fetchQuota: vi.fn(async () => {
+        throw new QuotaHttpError(401);
+      }),
+    });
+    seedCache({
+      version: 1,
+      cooldowns: {},
+      profiles: {
+        [TARGET.id]: { state: "ok", fetchedAt: NOW - 30 * 60_000, weekly: { usedPercent: 42, resetsAt: null } },
+      },
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(result[TARGET.id]).toMatchObject({ state: "expired", weekly: { usedPercent: 42 } });
+    // fetchedAt still points at when those numbers were true, not at this attempt.
+    expect(result[TARGET.id]?.fetchedAt).toBe(NOW - 30 * 60_000);
+  });
+
+  it("records a tool-wide cooldown from a 429 Retry-After", async () => {
+    stubAdapter({
+      fetchQuota: vi.fn(async () => {
+        throw new QuotaHttpError(429, "3600");
+      }),
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(result[TARGET.id]?.state).toBe("cooldown");
+    expect(readCacheFile().cooldowns.claude).toBe(NOW + 3_600_000);
+  });
+
+  it("makes no request at all while the tool is cooling down", async () => {
+    const adapter = stubAdapter();
+    seedCache({
+      version: 1,
+      cooldowns: { claude: NOW + 60_000 },
+      profiles: {
+        [TARGET.id]: { state: "ok", fetchedAt: NOW - 30 * 60_000, weekly: { usedPercent: 42, resetsAt: null } },
+      },
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.fetchQuota).not.toHaveBeenCalled();
+    expect(result[TARGET.id]).toMatchObject({ state: "cooldown", weekly: { usedPercent: 42 } });
+  });
+
+  it("resumes fetching once the cooldown has elapsed", async () => {
+    const adapter = stubAdapter();
+    seedCache({ version: 1, cooldowns: { claude: NOW - 1 }, profiles: {} });
+
+    await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.fetchQuota).toHaveBeenCalledTimes(1);
+  });
+
+  it("one profile's 429 stops the rest of that tool's fetches from being retried later", async () => {
+    stubAdapter({
+      fetchQuota: vi.fn(async () => {
+        throw new QuotaHttpError(429, "600");
+      }),
+    });
+    const second = { id: "claude:other", tool: "claude" as const, configDir: "/tmp/.claude-other" };
+
+    await collectQuotas([TARGET, second], { now: NOW, cachePath });
+
+    expect(readCacheFile().cooldowns.claude).toBe(NOW + 600_000);
+  });
+
+  it("degrades to error on an unexpected status", async () => {
+    stubAdapter({
+      fetchQuota: vi.fn(async () => {
+        throw new QuotaHttpError(500);
+      }),
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(result[TARGET.id]?.state).toBe("error");
+    expect(readCacheFile().cooldowns).toEqual({});
+  });
+
+  it("degrades to error when the request throws or times out", async () => {
+    stubAdapter({
+      fetchQuota: vi.fn(async () => {
+        throw new Error("aborted");
+      }),
+    });
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(result[TARGET.id]?.state).toBe("error");
+  });
+
+  it("ignores a cache file it cannot understand", async () => {
+    const adapter = stubAdapter();
+    writeFileSync(cachePath, "{ not json", "utf8");
+
+    const result = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(adapter.fetchQuota).toHaveBeenCalledTimes(1);
+    expect(result[TARGET.id]?.state).toBe("ok");
+  });
+
+  it("lets only one concurrent renewal through, so the token rotates once", async () => {
+    // Two clausona processes hitting the same lapsed profile: the loser must not
+    // fire a second rotation, which would invalidate whatever the winner just stored.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const adapter = stubAdapter({
+      readCredential: vi.fn(async () => ({ accessToken: "old", refreshToken: "r", expiresAt: NOW - 1 })),
+      renewCredential: vi.fn(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight -= 1;
+        return { accessToken: "new", refreshToken: "r2", expiresAt: NOW + 8 * 3600_000 };
+      }),
+    });
+
+    const [a, b] = await Promise.all([
+      collectQuotas([TARGET], { now: NOW, cachePath }),
+      collectQuotas([TARGET], { now: NOW, cachePath }),
+    ]);
+
+    expect(maxInFlight).toBe(1);
+    expect(adapter.renewCredential).toHaveBeenCalledTimes(1);
+    // The one that could not take the lock backs off rather than rotating anyway.
+    expect([a[TARGET.id]?.state, b[TARGET.id]?.state].sort()).toEqual(["expired", "ok"]);
+  });
+
+  it("does no work for an empty target list", async () => {
+    const adapter = stubAdapter();
+
+    expect(await collectQuotas([], { now: NOW, cachePath })).toEqual({});
+    expect(adapter.readCredential).not.toHaveBeenCalled();
+  });
+
+  it("treats a tool with no quota support as missing", async () => {
+    getAdapter.mockReturnValue({} as ToolAdapter);
+
+    const result: Record<string, QuotaSnapshot> = await collectQuotas([TARGET], { now: NOW, cachePath });
+
+    expect(result[TARGET.id]?.state).toBe("missing");
+  });
+});

--- a/src/core/quota-store.ts
+++ b/src/core/quota-store.ts
@@ -1,0 +1,263 @@
+import crypto from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { getAdapter } from "../tools/registry.js";
+import type { ToolCredential } from "../tools/types.js";
+import type { QuotaSnapshot, QuotaWindows, ToolName } from "../types.js";
+import { cooldownUntil, isFresh, QUOTA_TIMEOUT_MS, QuotaHttpError } from "./quota.js";
+
+const DEFAULT_CACHE_PATH = path.join(homedir(), ".clausona", "quota.json");
+
+/** Renew a hair before expiry so a token cannot lapse mid-request. */
+const RENEW_MARGIN_MS = 60 * 1000;
+
+/** A lock older than this is treated as abandoned by a crashed process. */
+const LOCK_STALE_MS = 60 * 1000;
+
+type QuotaCache = {
+  version: 1;
+  /** ms epoch until which a tool's endpoint is left alone after a 429. */
+  cooldowns: Partial<Record<ToolName, number>>;
+  profiles: Record<string, QuotaSnapshot>;
+};
+
+// Must build a fresh object every call: a shared constant would be spread shallowly,
+// leaving every caller mutating the same `cooldowns` and `profiles` maps.
+function emptyCache(): QuotaCache {
+  return { version: 1, cooldowns: {}, profiles: {} };
+}
+
+async function readCache(cachePath: string): Promise<QuotaCache> {
+  try {
+    const parsed = JSON.parse(await readFile(cachePath, "utf8")) as Partial<QuotaCache>;
+    if (parsed.version !== 1) return emptyCache();
+    return {
+      version: 1,
+      cooldowns: parsed.cooldowns ?? {},
+      profiles: parsed.profiles ?? {},
+    };
+  } catch {
+    return emptyCache();
+  }
+}
+
+async function writeCache(cachePath: string, cache: QuotaCache): Promise<void> {
+  try {
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    const tmpPath = `${cachePath}.tmp.${process.pid}`;
+    await writeFile(tmpPath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+    await rename(tmpPath, cachePath);
+  } catch {
+    // A quota cache that cannot be persisted only costs an extra fetch next time.
+  }
+}
+
+function windowsOf(snapshot: QuotaSnapshot): QuotaWindows {
+  return { session: snapshot.session, weekly: snapshot.weekly, scoped: snapshot.scoped };
+}
+
+function hasWindows(snapshot: QuotaSnapshot | undefined): snapshot is QuotaSnapshot {
+  return Boolean(snapshot && (snapshot.session ?? snapshot.weekly ?? snapshot.scoped));
+}
+
+/**
+ * Reports a failure without throwing away what was last known. The numbers stay
+ * attached (stamped with when they were true) so the UI can dim them rather than
+ * blanking the row, while `state` explains why they were not refreshed.
+ */
+function degraded(state: QuotaSnapshot["state"], cached: QuotaSnapshot | undefined, now: number): QuotaSnapshot {
+  if (hasWindows(cached)) return { ...windowsOf(cached), state, fetchedAt: cached.fetchedAt };
+  return { state, fetchedAt: now };
+}
+
+/**
+ * Serializes renewal per profile. Two processes renewing the same credential would
+ * each rotate the refresh token, and whichever wrote first would be left holding a
+ * token the provider has already invalidated.
+ */
+async function withRenewalLock<T>(lockDir: string, profileId: string, fn: () => Promise<T>): Promise<T | null> {
+  const key = crypto.createHash("sha256").update(profileId).digest("hex").slice(0, 16);
+  const lockPath = path.join(lockDir, `${key}.lock`);
+  await mkdir(lockDir, { recursive: true }).catch(() => {});
+
+  const acquire = async () => {
+    try {
+      await writeFile(lockPath, String(process.pid), { flag: "wx" });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  if (!(await acquire())) {
+    const age = await stat(lockPath)
+      .then((info) => Date.now() - info.mtimeMs)
+      .catch(() => Number.POSITIVE_INFINITY);
+    // Only reclaim a lock old enough that its owner cannot still be mid-renewal.
+    if (age < LOCK_STALE_MS) return null;
+    await rm(lockPath, { force: true }).catch(() => {});
+    if (!(await acquire())) return null;
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await rm(lockPath, { force: true }).catch(() => {});
+  }
+}
+
+export type QuotaTarget = {
+  id: string;
+  tool: ToolName;
+  configDir: string;
+};
+
+/**
+ * Renews under a lock, returning null when renewal is impossible or another process
+ * already holds the lock. Errors are contained: a profile that cannot be renewed is
+ * reported as expired rather than failing the whole listing.
+ */
+async function renewCredential(
+  target: QuotaTarget,
+  credential: ToolCredential,
+  signal: AbortSignal,
+  lockDir: string,
+): Promise<ToolCredential | null> {
+  const adapter = getAdapter(target.tool);
+  if (!adapter.renewCredential || !credential.refreshToken) return null;
+
+  return withRenewalLock(lockDir, target.id, async () => {
+    try {
+      return (await adapter.renewCredential?.(target.configDir, credential, signal)) ?? null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+async function fetchOne(
+  target: QuotaTarget,
+  cache: QuotaCache,
+  now: number,
+  allowRenew: boolean,
+  lockDir: string,
+): Promise<{ snapshot: QuotaSnapshot; cooldown?: number }> {
+  const cached = cache.profiles[target.id];
+  const adapter = getAdapter(target.tool);
+
+  if (!adapter.readCredential || !adapter.fetchQuota) {
+    return { snapshot: degraded("missing", cached, now) };
+  }
+
+  let credential = await adapter.readCredential(target.configDir);
+  if (!credential) {
+    return { snapshot: degraded("missing", cached, now) };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), QUOTA_TIMEOUT_MS);
+
+  // At most one renewal per lookup, so a profile whose refresh token is also dead
+  // cannot spin.
+  let renewed = false;
+
+  const renew = async (): Promise<boolean> => {
+    if (!allowRenew || renewed) return false;
+    renewed = true;
+    const next = await renewCredential(target, credential as ToolCredential, controller.signal, lockDir);
+    if (!next) return false;
+    credential = next;
+    return true;
+  };
+
+  try {
+    // A lapsed access token can still be renewed from the refresh token, so this is
+    // worth doing rather than reporting expired straight away.
+    if (credential.expiresAt !== undefined && credential.expiresAt <= now + RENEW_MARGIN_MS) {
+      if (!(await renew())) return { snapshot: degraded("expired", cached, now) };
+    }
+
+    for (;;) {
+      try {
+        const windows = await adapter.fetchQuota(credential, controller.signal);
+        if (!windows) return { snapshot: degraded("error", cached, now) };
+        return { snapshot: { ...windows, state: "ok", fetchedAt: now } };
+      } catch (error) {
+        if (error instanceof QuotaHttpError) {
+          // A token can be rejected while still looking valid by the clock — revoked
+          // elsewhere, or skew — so a 401 earns one renewal attempt too.
+          if (error.status === 401 || error.status === 403) {
+            if (await renew()) continue;
+            return { snapshot: degraded("expired", cached, now) };
+          }
+          if (error.status === 429) {
+            return {
+              snapshot: degraded("cooldown", cached, now),
+              cooldown: cooldownUntil(error.retryAfter, now),
+            };
+          }
+        }
+        return { snapshot: degraded("error", cached, now) };
+      }
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolves quota for every target, preferring the on-disk cache and touching the
+ * network only for entries that are stale and whose endpoint is not cooling down.
+ * Never throws and never rejects: a profile that cannot be resolved comes back with
+ * a failure state instead.
+ */
+export async function collectQuotas(
+  targets: QuotaTarget[],
+  options: { refresh?: boolean; renew?: boolean; now?: number; cachePath?: string } = {},
+): Promise<Record<string, QuotaSnapshot>> {
+  if (targets.length === 0) return {};
+
+  const now = options.now ?? Date.now();
+  const cachePath = options.cachePath ?? DEFAULT_CACHE_PATH;
+  const cache = await readCache(cachePath);
+  const result: Record<string, QuotaSnapshot> = {};
+
+  const pending: QuotaTarget[] = [];
+  for (const target of targets) {
+    const cached = cache.profiles[target.id];
+    if (cached && !options.refresh && isFresh(cached, now)) {
+      result[target.id] = cached;
+      continue;
+    }
+
+    const cooldownUntilMs = cache.cooldowns[target.tool] ?? 0;
+    if (cooldownUntilMs > now) {
+      result[target.id] = degraded("cooldown", cached, now);
+      continue;
+    }
+
+    pending.push(target);
+  }
+
+  if (pending.length === 0) return result;
+
+  const allowRenew = options.renew ?? true;
+  const lockDir = path.join(path.dirname(cachePath), "locks");
+  const settled = await Promise.all(pending.map((target) => fetchOne(target, cache, now, allowRenew, lockDir)));
+
+  pending.forEach((target, index) => {
+    const { snapshot, cooldown } = settled[index];
+    result[target.id] = snapshot;
+    cache.profiles[target.id] = snapshot;
+    if (cooldown !== undefined) {
+      // One 429 pauses the whole tool: the limit is per-IP, not per-account, so
+      // retrying with a different profile's token would only extend the block.
+      cache.cooldowns[target.tool] = Math.max(cache.cooldowns[target.tool] ?? 0, cooldown);
+    }
+  });
+
+  await writeCache(cachePath, cache);
+  return result;
+}

--- a/src/core/quota.test.ts
+++ b/src/core/quota.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import { cooldownUntil, isFresh, parseClaudeQuota, parseCodexQuota, QUOTA_DEFAULT_COOLDOWN_MS } from "./quota.js";
+
+// Trimmed from a live GET /api/oauth/usage response.
+const CLAUDE_PAYLOAD = {
+  five_hour: { utilization: 1.0, resets_at: "2026-09-04T02:19:59.919263+00:00", limit_dollars: null },
+  seven_day: { utilization: 45.0, resets_at: "2026-09-04T19:59:59.919283+00:00", limit_dollars: null },
+  seven_day_opus: null,
+  seven_day_sonnet: null,
+  extra_usage: { is_enabled: false, monthly_limit: null },
+  limits: [
+    {
+      kind: "session",
+      group: "session",
+      percent: 1,
+      severity: "normal",
+      resets_at: "2026-09-04T02:19:59Z",
+      scope: null,
+    },
+    {
+      kind: "weekly_all",
+      group: "weekly",
+      percent: 45,
+      severity: "normal",
+      resets_at: "2026-09-04T19:59:59Z",
+      scope: null,
+    },
+    {
+      kind: "weekly_scoped",
+      group: "weekly",
+      percent: 77,
+      severity: "warning",
+      resets_at: "2026-09-04T19:59:59Z",
+      scope: { model: { id: null, display_name: "Fable" }, surface: null },
+    },
+  ],
+};
+
+// Trimmed from a live GET /backend-api/codex/usage response.
+const CODEX_PAYLOAD = {
+  plan_type: "pro",
+  rate_limit: {
+    allowed: true,
+    primary_window: {
+      used_percent: 12,
+      limit_window_seconds: 604800,
+      reset_after_seconds: 530735,
+      reset_at: 1789001823,
+    },
+    secondary_window: null,
+  },
+  additional_rate_limits: [
+    {
+      limit_name: "GPT-5.3-Codex-Spark",
+      rate_limit: { primary_window: { used_percent: 40, limit_window_seconds: 604800, reset_at: 1789001823 } },
+    },
+  ],
+};
+
+describe("parseClaudeQuota", () => {
+  it("maps the five-hour and seven-day windows", () => {
+    const quota = parseClaudeQuota(CLAUDE_PAYLOAD);
+
+    expect(quota?.session).toEqual({ usedPercent: 1, resetsAt: "2026-09-04T02:19:59.919Z" });
+    expect(quota?.weekly).toEqual({ usedPercent: 45, resetsAt: "2026-09-04T19:59:59.919Z" });
+  });
+
+  it("picks the highest model-scoped weekly limit", () => {
+    const quota = parseClaudeQuota({
+      ...CLAUDE_PAYLOAD,
+      limits: [
+        ...CLAUDE_PAYLOAD.limits,
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 90,
+          severity: "critical",
+          resets_at: "2026-09-05T00:00:00Z",
+          scope: { model: { display_name: "Opus" }, surface: null },
+        },
+      ],
+    });
+
+    expect(quota?.scoped).toEqual({ usedPercent: 90, resetsAt: "2026-09-05T00:00:00.000Z", label: "Opus" });
+  });
+
+  it("omits windows the account does not have", () => {
+    const quota = parseClaudeQuota({ five_hour: { utilization: 3, resets_at: null }, seven_day: null, limits: null });
+
+    expect(quota?.session).toEqual({ usedPercent: 3, resetsAt: null });
+    expect(quota?.weekly).toBeUndefined();
+    expect(quota?.scoped).toBeUndefined();
+  });
+
+  it("returns null when no window is present", () => {
+    expect(parseClaudeQuota({ five_hour: null, seven_day: null, limits: [] })).toBeNull();
+    expect(parseClaudeQuota(null)).toBeNull();
+    expect(parseClaudeQuota("nope")).toBeNull();
+  });
+
+  it("clamps out-of-range utilization", () => {
+    const quota = parseClaudeQuota({ five_hour: { utilization: 140, resets_at: null } });
+
+    expect(quota?.session?.usedPercent).toBe(100);
+  });
+});
+
+describe("parseCodexQuota", () => {
+  it("classifies windows by their declared width, not their position", () => {
+    const quota = parseCodexQuota(CODEX_PAYLOAD);
+
+    // primary_window is seven days here, so it must land on `weekly`.
+    expect(quota?.weekly).toEqual({ usedPercent: 12, resetsAt: "2026-09-10T00:57:03.000Z" });
+    expect(quota?.session).toBeUndefined();
+  });
+
+  it("treats a sub-day window as the session window", () => {
+    const quota = parseCodexQuota({
+      rate_limit: {
+        primary_window: { used_percent: 8, limit_window_seconds: 18000, reset_at: 1789001823 },
+        secondary_window: { used_percent: 55, limit_window_seconds: 604800, reset_at: 1789501823 },
+      },
+    });
+
+    expect(quota?.session?.usedPercent).toBe(8);
+    expect(quota?.weekly?.usedPercent).toBe(55);
+  });
+
+  it("surfaces the highest additional rate limit as the scoped window", () => {
+    const quota = parseCodexQuota(CODEX_PAYLOAD);
+
+    expect(quota?.scoped).toEqual({
+      usedPercent: 40,
+      resetsAt: "2026-09-10T00:57:03.000Z",
+      label: "GPT-5.3-Codex-Spark",
+    });
+  });
+
+  it("returns null when the payload carries no windows", () => {
+    expect(parseCodexQuota({ rate_limit: { primary_window: null, secondary_window: null } })).toBeNull();
+    expect(parseCodexQuota(undefined)).toBeNull();
+  });
+});
+
+describe("cache policy", () => {
+  const now = 1_800_000_000_000;
+
+  it("serves a snapshot fetched within the freshness window", () => {
+    expect(isFresh({ fetchedAt: now - 60_000 }, now)).toBe(true);
+    expect(isFresh({ fetchedAt: now - 10 * 60_000 }, now)).toBe(false);
+  });
+
+  it("rejects a snapshot stamped in the future", () => {
+    expect(isFresh({ fetchedAt: now + 60_000 }, now)).toBe(false);
+  });
+});
+
+describe("cooldownUntil", () => {
+  it("honours Retry-After", () => {
+    expect(cooldownUntil("3600", 1000)).toBe(1000 + 3600 * 1000);
+  });
+
+  it("falls back when the header is absent or unusable", () => {
+    expect(cooldownUntil(null, 1000)).toBe(1000 + QUOTA_DEFAULT_COOLDOWN_MS);
+    expect(cooldownUntil("soon", 1000)).toBe(1000 + QUOTA_DEFAULT_COOLDOWN_MS);
+    expect(cooldownUntil("-5", 1000)).toBe(1000 + QUOTA_DEFAULT_COOLDOWN_MS);
+  });
+
+  it("caps an absurd Retry-After at a day", () => {
+    expect(cooldownUntil("999999", 0)).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/src/core/quota.ts
+++ b/src/core/quota.ts
@@ -1,0 +1,172 @@
+import type { QuotaWindow, QuotaWindows } from "../types.js";
+
+/** How long a cached snapshot is served without touching the network. */
+export const QUOTA_FRESH_MS = 5 * 60 * 1000;
+
+/** Fallback cooldown when a 429 arrives without a usable Retry-After. */
+export const QUOTA_DEFAULT_COOLDOWN_MS = 60 * 60 * 1000;
+
+/** Requests are abandoned at this point; Claude Code uses the same budget. */
+export const QUOTA_TIMEOUT_MS = 5000;
+
+/** Carries the HTTP status so the caller can tell 401 (expired) from 429 (cooldown). */
+export class QuotaHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly retryAfter: string | null = null,
+  ) {
+    super(`quota endpoint returned ${status}`);
+    this.name = "QuotaHttpError";
+  }
+}
+
+function toPercent(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, value));
+}
+
+function toIso(value: unknown): string | null {
+  if (typeof value !== "string" || value === "") return null;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+}
+
+function toIsoFromEpochSeconds(value: unknown): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return null;
+  return new Date(value * 1000).toISOString();
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Claude reports each window as `{ utilization, resets_at }`, where a window the
+ * account does not have (e.g. seven_day_opus on a non-Opus plan) is null.
+ */
+function claudeWindow(value: unknown): QuotaWindow | undefined {
+  const obj = record(value);
+  if (!obj) return undefined;
+  const usedPercent = toPercent(obj.utilization);
+  if (usedPercent === null) return undefined;
+  return { usedPercent, resetsAt: toIso(obj.resets_at) };
+}
+
+/**
+ * Picks the most-consumed scoped limit (Claude reports one entry per model, so the
+ * binding one is whichever sits highest).
+ */
+function claudeScoped(value: unknown): (QuotaWindow & { label: string }) | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  let best: (QuotaWindow & { label: string }) | undefined;
+  for (const entry of value) {
+    const obj = record(entry);
+    if (!obj || obj.kind !== "weekly_scoped") continue;
+
+    const usedPercent = toPercent(obj.percent);
+    if (usedPercent === null) continue;
+
+    const label = record(record(obj.scope)?.model)?.display_name;
+    if (typeof label !== "string" || label === "") continue;
+
+    if (!best || usedPercent > best.usedPercent) {
+      best = { usedPercent, resetsAt: toIso(obj.resets_at), label };
+    }
+  }
+  return best;
+}
+
+/** Parses `GET https://api.anthropic.com/api/oauth/usage`. */
+export function parseClaudeQuota(raw: unknown): QuotaWindows | null {
+  const obj = record(raw);
+  if (!obj) return null;
+
+  const windows: QuotaWindows = {
+    session: claudeWindow(obj.five_hour),
+    weekly: claudeWindow(obj.seven_day),
+    scoped: claudeScoped(obj.limits),
+  };
+
+  return hasAnyWindow(windows) ? windows : null;
+}
+
+/**
+ * Codex reports windows positionally (`primary`/`secondary`) but the period each one
+ * covers varies by plan, so they are classified by their declared width instead.
+ */
+function codexWindow(value: unknown): { window: QuotaWindow; seconds: number } | undefined {
+  const obj = record(value);
+  if (!obj) return undefined;
+
+  const usedPercent = toPercent(obj.used_percent);
+  if (usedPercent === null) return undefined;
+
+  const seconds = typeof obj.limit_window_seconds === "number" ? obj.limit_window_seconds : 0;
+  return { window: { usedPercent, resetsAt: toIsoFromEpochSeconds(obj.reset_at) }, seconds };
+}
+
+/** Windows at or below a day are the rolling session budget; anything longer is the weekly one. */
+const CODEX_SESSION_MAX_SECONDS = 24 * 60 * 60;
+
+/** Parses `GET https://chatgpt.com/backend-api/codex/usage`. */
+export function parseCodexQuota(raw: unknown): QuotaWindows | null {
+  const obj = record(raw);
+  if (!obj) return null;
+
+  const rateLimit = record(obj.rate_limit);
+  const windows: QuotaWindows = {};
+
+  for (const key of ["primary_window", "secondary_window"] as const) {
+    const parsed = codexWindow(rateLimit?.[key]);
+    if (!parsed) continue;
+    if (parsed.seconds > 0 && parsed.seconds <= CODEX_SESSION_MAX_SECONDS) {
+      windows.session = parsed.window;
+    } else {
+      windows.weekly = parsed.window;
+    }
+  }
+
+  if (Array.isArray(obj.additional_rate_limits)) {
+    for (const entry of obj.additional_rate_limits) {
+      const additional = record(entry);
+      if (!additional) continue;
+
+      const label = additional.limit_name;
+      if (typeof label !== "string" || label === "") continue;
+
+      const parsed = codexWindow(record(additional.rate_limit)?.primary_window);
+      if (!parsed) continue;
+
+      if (!windows.scoped || parsed.window.usedPercent > windows.scoped.usedPercent) {
+        windows.scoped = { ...parsed.window, label };
+      }
+    }
+  }
+
+  return hasAnyWindow(windows) ? windows : null;
+}
+
+function hasAnyWindow(windows: QuotaWindows): boolean {
+  return Boolean(windows.session ?? windows.weekly ?? windows.scoped);
+}
+
+/** True while a cached snapshot may be served without re-fetching. */
+export function isFresh(snapshot: { fetchedAt: number }, now: number): boolean {
+  const age = now - snapshot.fetchedAt;
+  return age >= 0 && age < QUOTA_FRESH_MS;
+}
+
+/**
+ * Anonymous calls to the Claude usage endpoint are rejected with a flat one-hour
+ * Retry-After, so a 429 is treated as a host-wide pause rather than something to retry.
+ */
+export function cooldownUntil(retryAfterHeader: string | null, now: number): number {
+  const seconds = Number(retryAfterHeader);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return now + Math.min(seconds, 24 * 60 * 60) * 1000;
+  }
+  return now + QUOTA_DEFAULT_COOLDOWN_MS;
+}

--- a/src/lib/cli-style.ts
+++ b/src/lib/cli-style.ts
@@ -87,6 +87,13 @@ export function stripAnsi(str: string) {
   return str.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
+/** Shorten plain text to fit a column, marking the cut with an ellipsis. */
+export function truncate(str: string, width: number) {
+  if (width <= 0) return "";
+  if (str.length <= width) return str;
+  return width === 1 ? symbol.ellipsis : `${str.slice(0, width - 1)}${symbol.ellipsis}`;
+}
+
 /** Pad a string that may contain ANSI codes to a visible width */
 export function padEnd(str: string, width: number) {
   const visible = stripAnsi(str).length;

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import type { ProfileListItem, QuotaSnapshot } from "../types.js";
+import { stripAnsi } from "./cli-style.js";
 import {
+  fitQuotaValue,
   formatAge,
   formatQuotaInline,
   formatQuotaPercent,
   formatResetIn,
+  formatResetShort,
+  LIST_MIN_WIDTH,
+  pickLayout,
+  quotaBar,
   quotaNotes,
   quotaSeverity,
+  renderList,
 } from "./format.js";
 
 function snapshot(overrides: Partial<QuotaSnapshot> = {}): QuotaSnapshot {
@@ -125,5 +132,156 @@ describe("quotaNotes", () => {
 
   it("is silent when everything is current", () => {
     expect(quotaNotes([item(snapshot()), item(undefined)])).toEqual([]);
+  });
+});
+
+describe("formatResetShort", () => {
+  const now = new Date("2026-09-04T00:00:00Z");
+  const at = (iso: string) => formatResetShort(iso, now);
+
+  it("collapses to a single unit for table cells", () => {
+    expect(at("2026-09-04T00:42:00Z")).toBe("42m");
+    expect(at("2026-09-04T02:10:00Z")).toBe("2h");
+    expect(at("2026-09-07T04:00:00Z")).toBe("3d");
+  });
+
+  it("never rounds a live window down to zero", () => {
+    expect(at("2026-09-04T00:00:30Z")).toBe("1m");
+    expect(at("2026-09-03T23:00:00Z")).toBe("now");
+  });
+
+  it("is empty when there is nothing to report", () => {
+    expect(formatResetShort(null, now)).toBe("");
+    expect(formatResetShort("nope", now)).toBe("");
+  });
+});
+
+describe("pickLayout", () => {
+  it("keeps every column when the terminal is wide", () => {
+    expect(pickLayout(true, 200).keys).toEqual(["profile", "account", "session", "weekly", "cost", "input", "output"]);
+  });
+
+  it("drops token counts before cost, and cost before quota", () => {
+    expect(pickLayout(true, 104).keys).not.toContain("output");
+    expect(pickLayout(true, 104).keys).toContain("cost");
+
+    const narrow = pickLayout(true, 80).keys;
+    expect(narrow).not.toContain("cost");
+    expect(narrow).toEqual(["profile", "account", "session", "weekly"]);
+  });
+
+  it("gives up reset times before it gives up the quota columns", () => {
+    expect(pickLayout(true, 78).reset).toBe(true);
+    expect(pickLayout(true, 70).reset).toBe(false);
+    expect(pickLayout(true, 70).keys).toContain("session");
+  });
+
+  it("shrinks the name and account columns as a last resort", () => {
+    const tiny = pickLayout(true, 40);
+    expect(tiny.profileWidth).toBeLessThan(20);
+    expect(tiny.accountWidth).toBeLessThan(32);
+    expect(tiny.keys).toContain("weekly");
+  });
+
+  it("keeps the pre-quota layout when quota is not shown", () => {
+    expect(pickLayout(false, 200).keys).toEqual(["profile", "account", "cost", "input", "output"]);
+  });
+});
+
+describe("renderList width", () => {
+  const item = (name: string, quota?: QuotaSnapshot): ProfileListItem => ({
+    name,
+    tool: "claude",
+    email: `${name}@example.com`,
+    configDir: `/home/u/.claude-${name}`,
+    isPrimary: false,
+    isActive: false,
+    quota,
+    today: { cost: 0, inputTokens: 0, outputTokens: 0 },
+    week: { cost: 1, inputTokens: 10, outputTokens: 5 },
+    month: { cost: 1, inputTokens: 10, outputTokens: 5 },
+    total: { cost: 1, inputTokens: 10, outputTokens: 5 },
+  });
+
+  const visibleWidth = (line: string) => stripAnsi(line).length;
+
+  it("never emits a line wider than the terminal", () => {
+    const items = [
+      item("a-very-long-profile-name-indeed", snapshot({ session: { usedPercent: 5, resetsAt: null } })),
+      item("short", snapshot({ weekly: { usedPercent: 100, resetsAt: "2030-01-01T00:00:00Z" } })),
+    ];
+
+    for (const width of [LIST_MIN_WIDTH, 60, 70, 78, 80, 90, 100, 104, 120, 200]) {
+      const lines = renderList(items, { width }).split("\n");
+      const over = lines.filter((line) => visibleWidth(line) > width);
+      expect(over, `width ${width} overflowed: ${JSON.stringify(over)}`).toEqual([]);
+    }
+  });
+
+  it("falls back to the narrowest layout below the guaranteed width", () => {
+    // Nothing left to drop: keeping the profile name readable beats fitting.
+    expect(LIST_MIN_WIDTH).toBeLessThanOrEqual(60);
+    expect(pickLayout(true, 20)).toEqual(pickLayout(true, LIST_MIN_WIDTH - 1));
+  });
+
+  it("shows the reset time alongside the percentage when there is room", () => {
+    // Half past, so the single-unit flooring cannot land on the neighbouring hour
+    // while the test runs.
+    const resetsAt = new Date(Date.now() + 3.5 * 3600_000).toISOString();
+    const out = stripAnsi(
+      renderList([item("work", snapshot({ session: { usedPercent: 42, resetsAt } }))], { width: 200 }),
+    );
+
+    expect(out).toContain("42% 3h");
+  });
+
+  it("drops the codex footnote once no spend column is left to explain", () => {
+    const codex = {
+      ...item("cdx"),
+      tool: "codex" as const,
+      quota: snapshot({ weekly: { usedPercent: 3, resetsAt: null } }),
+    };
+
+    expect(stripAnsi(renderList([codex], { width: 200 }))).toContain("not available for codex");
+    expect(stripAnsi(renderList([codex], { width: 80 }))).not.toContain("not available for codex");
+  });
+});
+
+describe("quotaBar", () => {
+  it("fills proportionally and always spans ten cells", () => {
+    expect(quotaBar(0)).toBe("░░░░░░░░░░");
+    expect(quotaBar(50)).toBe("█████░░░░░");
+    expect(quotaBar(100)).toBe("██████████");
+  });
+
+  it("clamps nonsense input", () => {
+    expect(quotaBar(-20)).toHaveLength(10);
+    expect(quotaBar(420)).toBe("██████████");
+  });
+});
+
+describe("fitQuotaValue", () => {
+  const now = new Date("2026-09-04T00:00:00Z");
+  const window = { usedPercent: 26, resetsAt: "2026-09-04T12:59:00Z" };
+
+  it("sheds the gauge, then the wording, then the reset time as space runs out", () => {
+    expect(fitQuotaValue(window, 40, now)).toBe("███░░░░░░░  26%  resets in 12h 59m");
+    expect(fitQuotaValue(window, 30, now)).toBe(" 26%  resets in 12h 59m");
+    expect(fitQuotaValue(window, 20, now)).toBe("███░░░░░░░  26% 12h");
+    expect(fitQuotaValue(window, 10, now)).toBe(" 26% 12h");
+    expect(fitQuotaValue(window, 5, now)).toBe(" 26%");
+  });
+
+  it("never exceeds the budget once the percentage alone fits", () => {
+    for (let width = 4; width <= 60; width += 1) {
+      expect(fitQuotaValue(window, width, now).length).toBeLessThanOrEqual(Math.max(width, 4));
+    }
+  });
+
+  it("omits reset wording entirely when the window reports no reset", () => {
+    const noReset = { usedPercent: 0, resetsAt: null };
+
+    expect(fitQuotaValue(noReset, 40, now)).toBe("░░░░░░░░░░   0%");
+    expect(fitQuotaValue(noReset, 5, now)).toBe("  0%");
   });
 });

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProfileListItem, QuotaSnapshot } from "../types.js";
+import {
+  formatAge,
+  formatQuotaInline,
+  formatQuotaPercent,
+  formatResetIn,
+  quotaNotes,
+  quotaSeverity,
+} from "./format.js";
+
+function snapshot(overrides: Partial<QuotaSnapshot> = {}): QuotaSnapshot {
+  return { state: "ok", fetchedAt: 0, ...overrides };
+}
+
+describe("formatQuotaPercent", () => {
+  it("rounds to a whole percent", () => {
+    expect(formatQuotaPercent({ usedPercent: 44.6, resetsAt: null })).toBe("45%");
+  });
+
+  it("renders an em dash when the window is absent", () => {
+    expect(formatQuotaPercent(undefined)).toBe("—");
+  });
+});
+
+describe("formatResetIn", () => {
+  const now = new Date("2026-09-04T00:00:00Z");
+
+  it("formats sub-hour, hour, and multi-day gaps", () => {
+    expect(formatResetIn("2026-09-04T00:42:00Z", now)).toBe("42m");
+    expect(formatResetIn("2026-09-04T02:10:00Z", now)).toBe("2h 10m");
+    expect(formatResetIn("2026-09-04T05:00:00Z", now)).toBe("5h");
+    expect(formatResetIn("2026-09-07T04:00:00Z", now)).toBe("3d 4h");
+    expect(formatResetIn("2026-09-07T00:00:00Z", now)).toBe("3d");
+  });
+
+  it("collapses an elapsed window to `now`", () => {
+    expect(formatResetIn("2026-09-03T23:00:00Z", now)).toBe("now");
+  });
+
+  it("handles a missing or unparseable timestamp", () => {
+    expect(formatResetIn(null, now)).toBe("—");
+    expect(formatResetIn("not a date", now)).toBe("—");
+  });
+});
+
+describe("formatAge", () => {
+  const now = new Date("2026-09-04T12:00:00Z");
+  const at = (iso: string) => formatAge(Date.parse(iso), now);
+
+  it("describes how long ago a reading was taken", () => {
+    expect(at("2026-09-04T11:58:00Z")).toBe("2m ago");
+    expect(at("2026-09-04T09:00:00Z")).toBe("3h ago");
+    expect(at("2026-09-01T09:00:00Z")).toBe("3d ago");
+  });
+
+  it("collapses anything under a minute", () => {
+    expect(at("2026-09-04T11:59:30Z")).toBe("just now");
+  });
+});
+
+describe("formatQuotaInline", () => {
+  it("joins the windows it has", () => {
+    const quota = snapshot({
+      session: { usedPercent: 61, resetsAt: null },
+      weekly: { usedPercent: 100, resetsAt: null },
+    });
+
+    expect(formatQuotaInline(quota)).toBe("5h 61% | 7d 100%");
+  });
+
+  it("omits a window the plan does not report", () => {
+    expect(formatQuotaInline(snapshot({ weekly: { usedPercent: 4, resetsAt: null } }))).toBe("7d 4%");
+  });
+
+  it("flags a reading that is not current", () => {
+    const quota = snapshot({ state: "cooldown", weekly: { usedPercent: 4, resetsAt: null } });
+
+    expect(formatQuotaInline(quota)).toBe("7d 4% (cooldown)");
+  });
+
+  it("falls back to the bare state when there are no numbers", () => {
+    expect(formatQuotaInline(snapshot({ state: "expired" }))).toBe("expired");
+    expect(formatQuotaInline(undefined)).toBe("");
+  });
+});
+
+describe("quotaSeverity", () => {
+  it("grades on the most-consumed window", () => {
+    const peak = (session: number, weekly: number) =>
+      quotaSeverity(
+        snapshot({
+          session: { usedPercent: session, resetsAt: null },
+          weekly: { usedPercent: weekly, resetsAt: null },
+        }),
+      );
+
+    expect(peak(5, 46)).toBe("healthy");
+    expect(peak(5, 77)).toBe("warning");
+    expect(peak(100, 46)).toBe("error");
+  });
+
+  it("stays neutral when the reading is not live", () => {
+    expect(quotaSeverity(snapshot({ state: "cooldown", weekly: { usedPercent: 100, resetsAt: null } }))).toBe("muted");
+    expect(quotaSeverity(undefined)).toBe("muted");
+  });
+});
+
+describe("quotaNotes", () => {
+  const item = (quota?: QuotaSnapshot) => ({ quota }) as ProfileListItem;
+
+  it("emits one note per distinct problem", () => {
+    const notes = quotaNotes([
+      item(snapshot()),
+      item(snapshot({ state: "expired" })),
+      item(snapshot({ state: "expired" })),
+      item(snapshot({ state: "missing" })),
+    ]);
+
+    expect(notes).toHaveLength(2);
+    expect(notes[0]).toMatch(/^expired: /);
+    expect(notes[1]).toMatch(/^missing: /);
+  });
+
+  it("is silent when everything is current", () => {
+    expect(quotaNotes([item(snapshot()), item(undefined)])).toEqual([]);
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -117,6 +117,49 @@ export function formatAge(fetchedAt: number, now: Date = new Date()): string {
   return `${minutes}m ago`;
 }
 
+/** Coarsest useful "time until reset" — one unit, for table cells. */
+export function formatResetShort(resetsAt: string | null | undefined, now: Date = new Date()): string {
+  if (!resetsAt) return "";
+  const ms = Date.parse(resetsAt) - now.getTime();
+  if (Number.isNaN(ms)) return "";
+  if (ms <= 0) return "now";
+
+  const minutes = Math.floor(ms / 60000);
+  if (minutes >= 1440) return `${Math.floor(minutes / 1440)}d`;
+  if (minutes >= 60) return `${Math.floor(minutes / 60)}h`;
+  return `${Math.max(1, minutes)}m`;
+}
+
+/** A 10-cell gauge reads faster than a number when scanning several accounts. */
+export function quotaBar(usedPercent: number): string {
+  const filled = Math.min(10, Math.max(0, Math.round(usedPercent / 10)));
+  return `${"\u2588".repeat(filled)}${"\u2591".repeat(10 - filled)}`;
+}
+
+/**
+ * Most detailed rendering of a window that fits `width`, shedding the gauge, then the
+ * wording, then the reset time. The percentage is never dropped, so a value can still
+ * exceed `width` when even that does not fit.
+ */
+export function fitQuotaValue(window: QuotaWindow, width: number, now: Date = new Date()): string {
+  const percent = formatQuotaPercent(window).padStart(4);
+  const long = formatResetIn(window.resetsAt, now);
+  const short = formatResetShort(window.resetsAt, now);
+  const gauge = quotaBar(window.usedPercent);
+
+  const candidates = short
+    ? [
+        `${gauge} ${percent}  resets in ${long}`,
+        `${percent}  resets in ${long}`,
+        `${gauge} ${percent} ${short}`,
+        `${percent} ${short}`,
+        percent,
+      ]
+    : [`${gauge} ${percent}`, percent];
+
+  return candidates.find((candidate) => candidate.length <= width) ?? percent;
+}
+
 const QUOTA_NOTES: Record<Exclude<QuotaSnapshot["state"], "ok">, string> = {
   expired: "sign-in has lapsed — run `clausona login <profile>`",
   missing: "no stored credential for this profile",
@@ -135,7 +178,110 @@ export function quotaNotes(items: ProfileListItem[]): string[] {
 }
 
 // ─── List ───────────────────────────────────────────────────────────
-export function renderList(items: ProfileListItem[]) {
+type ColumnKey = "profile" | "account" | "session" | "weekly" | "cost" | "input" | "output";
+
+const QUOTA_WIDTH_WITH_RESET = 11;
+const QUOTA_WIDTH_PLAIN = 7;
+
+type Layout = {
+  keys: ColumnKey[];
+  /** Whether quota cells carry their reset time. */
+  reset: boolean;
+  profileWidth: number;
+  accountWidth: number;
+};
+
+const LABELS: Record<ColumnKey, string> = {
+  profile: "PROFILE",
+  account: "ACCOUNT",
+  session: "5H",
+  weekly: "7D",
+  cost: "COST",
+  input: "INPUT",
+  output: "OUTPUT",
+};
+
+const FIXED_WIDTHS = { cost: 12, input: 14, output: 10 } as const;
+
+function columnWidth(key: ColumnKey, layout: Layout): number {
+  switch (key) {
+    case "profile":
+      return layout.profileWidth;
+    case "account":
+      return layout.accountWidth;
+    case "session":
+    case "weekly":
+      return layout.reset ? QUOTA_WIDTH_WITH_RESET : QUOTA_WIDTH_PLAIN;
+    default:
+      return FIXED_WIDTHS[key];
+  }
+}
+
+const INDENT = 4;
+
+function layoutWidth(layout: Layout): number {
+  return INDENT + layout.keys.reduce((sum, key) => sum + columnWidth(key, layout), 0);
+}
+
+/**
+ * Progressively narrower fallbacks, widest first. Cost and token counts give way
+ * before the quota pair does: quota is why you run the command, and the spend figures
+ * are still available in full from `clausona usage`.
+ */
+function candidateLayouts(showQuota: boolean): Layout[] {
+  const base = { profileWidth: 20, accountWidth: 32 };
+  const tail: ColumnKey[][] = [["cost", "input", "output"], ["cost", "input"], ["cost"], []];
+
+  if (!showQuota) {
+    return [
+      ...tail.map((extra) => ({ keys: ["profile", "account", ...extra] as ColumnKey[], reset: false, ...base })),
+      { keys: ["profile", "account", "cost"], reset: false, profileWidth: 14, accountWidth: 22 },
+    ];
+  }
+
+  const quota: ColumnKey[] = ["session", "weekly"];
+  return [
+    ...tail.map((extra) => ({
+      keys: ["profile", "account", ...quota, ...extra] as ColumnKey[],
+      reset: true,
+      ...base,
+    })),
+    { keys: ["profile", "account", ...quota], reset: false, ...base },
+    { keys: ["profile", "account", ...quota], reset: false, profileWidth: 14, accountWidth: 22 },
+  ];
+}
+
+/** Widest layout that fits; the narrowest is used when even that overflows. */
+export function pickLayout(showQuota: boolean, available: number): Layout {
+  const layouts = candidateLayouts(showQuota);
+  return layouts.find((layout) => layoutWidth(layout) <= available) ?? layouts[layouts.length - 1];
+}
+
+/**
+ * Narrowest terminal the table is guaranteed to fit. Below this there is nothing left
+ * to drop, so rows are allowed to overflow rather than losing the profile name.
+ */
+export const LIST_MIN_WIDTH = Math.max(
+  ...[true, false].map((showQuota) => {
+    const layouts = candidateLayouts(showQuota);
+    return layoutWidth(layouts[layouts.length - 1]);
+  }),
+);
+
+function quotaCell(
+  window: QuotaWindow | undefined,
+  state: QuotaSnapshot["state"] | undefined,
+  withReset: boolean,
+  now: Date,
+): string {
+  const percent = styledQuota(window, state);
+  if (!withReset || !window) return percent;
+
+  const reset = formatResetShort(window.resetsAt, now);
+  return reset ? `${percent} ${dimmer(reset)}` : percent;
+}
+
+export function renderList(items: ProfileListItem[], options: { width?: number } = {}) {
   const now = new Date();
   const weekAgo = new Date(now);
   weekAgo.setDate(weekAgo.getDate() - 7);
@@ -151,53 +297,52 @@ export function renderList(items: ProfileListItem[]) {
 
   // Quota columns are only worth their width once something has been fetched.
   const showQuota = sorted.some((item) => item.quota);
+  const available = options.width ?? process.stdout.columns ?? 120;
+  const layout = pickLayout(showQuota, available);
 
-  const cols = [
-    { label: "PROFILE", w: 20 },
-    { label: "ACCOUNT", w: 32 },
-    ...(showQuota
-      ? [
-          { label: "5H", w: 7 },
-          { label: "7D", w: 7 },
-        ]
-      : []),
-    { label: "COST", w: 12 },
-    { label: "INPUT", w: 14 },
-    { label: "OUTPUT", w: 10 },
-  ];
-  const headerLine = `    ${cols.map((c) => secondary(c.label.padEnd(c.w))).join("")}`;
-  const sep = `    ${dimmer("─".repeat(cols.reduce((s, c) => s + c.w, 0)))}`;
+  const widths = layout.keys.map((key) => columnWidth(key, layout));
+  const headerLine = `    ${layout.keys.map((key, i) => secondary(LABELS[key].padEnd(widths[i]))).join("")}`;
+  const sep = `    ${dimmer("─".repeat(widths.reduce((a, b) => a + b, 0)))}`;
 
+  // The footnote only earns its line while a column it explains is on screen.
+  const spendShown = layout.keys.some((key) => key === "cost" || key === "input" || key === "output");
   const hasCodex = sorted.some((item) => item.tool === "codex");
 
   const rows = sorted.map((item) => {
     const marker = item.isActive ? accent("▸") : " ";
-    // Truncate before styling so the ellipsis lands inside the column, not after it.
-    const rawName = truncate(item.name, 19);
-    const rawEmail = truncate(item.email, 31);
-    const name = pad(item.isActive ? accent(rawName) : rawName, 20);
-    const email = pad(item.isActive ? rawEmail : secondary(rawEmail), 32);
-    const quota = showQuota
-      ? pad(styledQuota(item.quota?.session, item.quota?.state), 7) +
-        pad(styledQuota(item.quota?.weekly, item.quota?.state), 7)
-      : "";
-    let cost: string;
-    let input: string;
-    let output: string;
-    if (item.tool === "codex") {
-      cost = pad(dim("—"), 12);
-      input = pad(dim("—"), 14);
-      output = `${dim("—")}  *`;
-    } else {
-      cost = pad(styledCost(item.week.cost), 12);
-      input = pad(styledCount(item.week.inputTokens), 14);
-      output = styledCount(item.week.outputTokens);
-    }
-    return `  ${marker} ${name}${email}${quota}${cost}${input}${output}`;
+    const isCodex = item.tool === "codex";
+
+    const cell = (key: ColumnKey): string => {
+      switch (key) {
+        case "profile": {
+          // Truncate before styling so the ellipsis lands inside the column.
+          const name = truncate(item.name, layout.profileWidth - 1);
+          return item.isActive ? accent(name) : name;
+        }
+        case "account": {
+          const email = truncate(item.email, layout.accountWidth - 1);
+          return item.isActive ? email : secondary(email);
+        }
+        case "session":
+          return quotaCell(item.quota?.session, item.quota?.state, layout.reset, now);
+        case "weekly":
+          return quotaCell(item.quota?.weekly, item.quota?.state, layout.reset, now);
+        case "cost":
+          return isCodex ? dim("—") : styledCost(item.week.cost);
+        case "input":
+          return isCodex ? dim("—") : styledCount(item.week.inputTokens);
+        case "output":
+          return isCodex ? dim("—") : styledCount(item.week.outputTokens);
+      }
+    };
+
+    const cells = layout.keys.map((key, i) => (i === layout.keys.length - 1 ? cell(key) : pad(cell(key), widths[i])));
+    const suffix = isCodex && spendShown ? `  ${dim("*")}` : "";
+    return `  ${marker} ${cells.join("")}${suffix}`;
   });
 
   const footnotes = [
-    ...(hasCodex ? ["* cost and token tracking are not available for codex"] : []),
+    ...(hasCodex && spendShown ? ["* cost and token tracking are not available for codex"] : []),
     ...quotaNotes(sorted),
   ].map((note) => `  ${dim(note)}`);
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,5 +1,5 @@
 import { symbol } from "../tui/theme.js";
-import type { DoctorProfileResult, ProfileListItem, UsageSummary } from "../types.js";
+import type { DoctorProfileResult, ProfileListItem, QuotaSnapshot, QuotaWindow, UsageSummary } from "../types.js";
 
 import {
   accent,
@@ -14,7 +14,9 @@ import {
   secondary,
   styledCost,
   styledCount,
+  truncate,
   fail as xMark,
+  yellow,
 } from "./cli-style.js";
 
 // ─── Timezone ────────────────────────────────────────────────────────
@@ -36,8 +38,100 @@ export function formatCount(value: number) {
   return value > 0 ? value.toLocaleString("en-US") : "—";
 }
 
+/** Compact one-line quota for dense rows, e.g. `5h 61% | 7d 100%`. */
+export function formatQuotaInline(quota: QuotaSnapshot | undefined): string {
+  if (!quota) return "";
+  const parts: string[] = [];
+  if (quota.session) parts.push(`5h ${formatQuotaPercent(quota.session)}`);
+  if (quota.weekly) parts.push(`7d ${formatQuotaPercent(quota.weekly)}`);
+  if (parts.length === 0) return quota.state === "ok" ? "" : quota.state;
+  const suffix = quota.state === "ok" ? "" : ` (${quota.state})`;
+  return `${parts.join(" | ")}${suffix}`;
+}
+
+/** Severity of the most-consumed window, for colouring a whole row at a glance. */
+export function quotaSeverity(quota: QuotaSnapshot | undefined): "healthy" | "warning" | "error" | "muted" {
+  if (!quota || quota.state !== "ok") return "muted";
+  const peak = Math.max(quota.session?.usedPercent ?? 0, quota.weekly?.usedPercent ?? 0);
+  if (peak >= QUOTA_CRITICAL) return "error";
+  if (peak >= QUOTA_WARNING) return "warning";
+  return "healthy";
+}
+
 export function formatUsage(summary: UsageSummary) {
   return `${formatCurrency(summary.cost)} | in ${formatCount(summary.inputTokens)} | out ${formatCount(summary.outputTokens)}`;
+}
+
+// ─── Quota ──────────────────────────────────────────────────────────
+/** Matches the severity bands the API itself reports (normal / warning / critical). */
+const QUOTA_CRITICAL = 90;
+const QUOTA_WARNING = 75;
+
+/** True when the reading is current rather than a last-known value. */
+function isLiveQuota(state: QuotaSnapshot["state"]): boolean {
+  return state === "ok";
+}
+
+export function formatQuotaPercent(window: QuotaWindow | undefined): string {
+  return window ? `${Math.round(window.usedPercent)}%` : "—";
+}
+
+/** Colours a percentage by severity; anything not freshly fetched is dimmed instead. */
+export function styledQuota(window: QuotaWindow | undefined, state: QuotaSnapshot["state"] | undefined): string {
+  if (!window || !state) return dim("—");
+  const text = formatQuotaPercent(window);
+  if (!isLiveQuota(state)) return dimmer(text);
+  if (window.usedPercent >= QUOTA_CRITICAL) return red(text);
+  if (window.usedPercent >= QUOTA_WARNING) return yellow(text);
+  return text;
+}
+
+/** Compact "time until reset", e.g. `2h 10m` or `3d 4h`. */
+export function formatResetIn(resetsAt: string | null | undefined, now: Date = new Date()): string {
+  if (!resetsAt) return "—";
+  const ms = Date.parse(resetsAt) - now.getTime();
+  if (Number.isNaN(ms)) return "—";
+  if (ms <= 0) return "now";
+
+  const minutes = Math.floor(ms / 60000);
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
+  const mins = minutes % 60;
+
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  if (hours > 0) return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  return `${mins}m`;
+}
+
+/** How long ago a reading was taken, e.g. `3h ago`. */
+export function formatAge(fetchedAt: number, now: Date = new Date()): string {
+  const ms = now.getTime() - fetchedAt;
+  if (!Number.isFinite(ms) || ms < 60_000) return "just now";
+
+  const minutes = Math.floor(ms / 60000);
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor(minutes / 60);
+
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  return `${minutes}m ago`;
+}
+
+const QUOTA_NOTES: Record<Exclude<QuotaSnapshot["state"], "ok">, string> = {
+  expired: "sign-in has lapsed — run `clausona login <profile>`",
+  missing: "no stored credential for this profile",
+  cooldown: "quota endpoint is rate limited; retrying later",
+  error: "quota lookup failed",
+};
+
+/** One footnote per distinct problem, so a wide table does not need a status column. */
+export function quotaNotes(items: ProfileListItem[]): string[] {
+  const states = new Set<Exclude<QuotaSnapshot["state"], "ok">>();
+  for (const item of items) {
+    const state = item.quota?.state;
+    if (state && state !== "ok") states.add(state);
+  }
+  return [...states].map((state) => `${state}: ${QUOTA_NOTES[state]}`);
 }
 
 // ─── List ───────────────────────────────────────────────────────────
@@ -55,9 +149,18 @@ export function renderList(items: ProfileListItem[]) {
     return a.name.localeCompare(b.name);
   });
 
+  // Quota columns are only worth their width once something has been fetched.
+  const showQuota = sorted.some((item) => item.quota);
+
   const cols = [
     { label: "PROFILE", w: 20 },
     { label: "ACCOUNT", w: 32 },
+    ...(showQuota
+      ? [
+          { label: "5H", w: 7 },
+          { label: "7D", w: 7 },
+        ]
+      : []),
     { label: "COST", w: 12 },
     { label: "INPUT", w: 14 },
     { label: "OUTPUT", w: 10 },
@@ -69,26 +172,36 @@ export function renderList(items: ProfileListItem[]) {
 
   const rows = sorted.map((item) => {
     const marker = item.isActive ? accent("▸") : " ";
-    const name = item.isActive ? pad(accent(item.name), cols[0].w) : item.name.padEnd(cols[0].w);
-    const email = pad(item.isActive ? item.email : secondary(item.email), cols[1].w);
+    // Truncate before styling so the ellipsis lands inside the column, not after it.
+    const rawName = truncate(item.name, 19);
+    const rawEmail = truncate(item.email, 31);
+    const name = pad(item.isActive ? accent(rawName) : rawName, 20);
+    const email = pad(item.isActive ? rawEmail : secondary(rawEmail), 32);
+    const quota = showQuota
+      ? pad(styledQuota(item.quota?.session, item.quota?.state), 7) +
+        pad(styledQuota(item.quota?.weekly, item.quota?.state), 7)
+      : "";
     let cost: string;
     let input: string;
     let output: string;
     if (item.tool === "codex") {
-      cost = pad(dim("—"), cols[2].w);
-      input = pad(dim("—"), cols[3].w);
+      cost = pad(dim("—"), 12);
+      input = pad(dim("—"), 14);
       output = `${dim("—")}  *`;
     } else {
-      cost = pad(styledCost(item.week.cost), cols[2].w);
-      input = pad(styledCount(item.week.inputTokens), cols[3].w);
+      cost = pad(styledCost(item.week.cost), 12);
+      input = pad(styledCount(item.week.inputTokens), 14);
       output = styledCount(item.week.outputTokens);
     }
-    return `  ${marker} ${name}${email}${cost}${input}${output}`;
+    return `  ${marker} ${name}${email}${quota}${cost}${input}${output}`;
   });
 
-  const footnote = hasCodex ? [`  ${dim("* usage tracking not supported for codex")}`] : [];
+  const footnotes = [
+    ...(hasCodex ? ["* cost and token tracking are not available for codex"] : []),
+    ...quotaNotes(sorted),
+  ].map((note) => `  ${dim(note)}`);
 
-  return ["", `  ${dim(range)}  ${dim(localTimezoneLabel())}`, "", headerLine, sep, ...rows, ...footnote, ""].join(
+  return ["", `  ${dim(range)}  ${dim(localTimezoneLabel())}`, "", headerLine, sep, ...rows, ...footnotes, ""].join(
     "\n",
   );
 }

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 
 import { evaluateSymlinkHealth } from "../core/doctor.js";
 import { backupDirFor, claudeJsonPathForConfigDir } from "../core/paths.js";
+import { collectQuotas, type QuotaTarget } from "../core/quota-store.js";
 import { isV1Registry, migrateRegistryV1toV2, setActiveProfile } from "../core/registry.js";
 import { renderShellInit } from "../core/shell.js";
 import { seedSeenSessions } from "../core/track-usage.js";
@@ -29,6 +30,7 @@ import type {
   DoctorProfileResult,
   Profile,
   ProfileListItem,
+  QuotaSnapshot,
   Registry,
   RegistryV1,
   ToolName,
@@ -696,7 +698,16 @@ export async function initializeRegistry(options: {
   return registry;
 }
 
-export async function listProfiles(): Promise<ProfileListItem[]> {
+export type ListProfilesOptions = {
+  /** Attach plan quota from each tool's usage endpoint. Off for callers that must stay offline. */
+  quota?: boolean;
+  /** Bypass the quota cache and re-fetch. */
+  refresh?: boolean;
+  /** Renew lapsed access tokens instead of reporting them as expired. Default on. */
+  renew?: boolean;
+};
+
+export async function listProfiles(options: ListProfilesOptions = {}): Promise<ProfileListItem[]> {
   const registry = await loadRegistry();
   if (!registry) {
     return [];
@@ -705,7 +716,19 @@ export async function listProfiles(): Promise<ProfileListItem[]> {
   const usage = await loadUsageStore();
   const now = new Date().toISOString(); // summarizeUsage interprets cutoffs in the runtime's local timezone
 
-  return Object.entries(registry.profiles).map(([id, profile]) => {
+  const entries = Object.entries(registry.profiles);
+
+  let quotas: Record<string, QuotaSnapshot> = {};
+  if (options.quota) {
+    const targets: QuotaTarget[] = entries.map(([id, profile]) => ({
+      id,
+      tool: profile.tool,
+      configDir: profile.configDir,
+    }));
+    quotas = await collectQuotas(targets, { refresh: options.refresh, renew: options.renew });
+  }
+
+  return entries.map(([id, profile]) => {
     const records = usage[id]?.records ?? [];
     return {
       name: id,
@@ -716,12 +739,27 @@ export async function listProfiles(): Promise<ProfileListItem[]> {
       isPrimary: Boolean(profile.isPrimary),
       isActive: registry.activeProfiles[profile.tool] === id,
       mergeSessions: profile.mergeSessions,
+      quota: quotas[id],
       today: summarizeUsage({ now, period: "today", records }),
       week: summarizeUsage({ now, period: "week", records }),
       month: summarizeUsage({ now, period: "month", records }),
       total: summarizeUsage({ now, period: "all", records }),
     };
   });
+}
+
+/**
+ * Resolves quota for already-listed profiles. Split out from listProfiles so the TUI
+ * can paint immediately and fill quota in once the network settles.
+ */
+export async function fetchProfileQuotas(
+  items: Pick<ProfileListItem, "name" | "tool" | "configDir">[],
+  options: { refresh?: boolean; renew?: boolean } = {},
+): Promise<Record<string, QuotaSnapshot>> {
+  return collectQuotas(
+    items.map((item) => ({ id: item.name, tool: item.tool, configDir: item.configDir })),
+    options,
+  );
 }
 
 export async function setActiveProfileByName(id: string) {

--- a/src/tools/claude.ts
+++ b/src/tools/claude.ts
@@ -1,12 +1,21 @@
 import { spawn } from "node:child_process";
 import crypto from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, rename, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import { claudeJsonPathForConfigDir } from "../core/paths.js";
-import type { ToolAdapter } from "./types.js";
+import { parseClaudeQuota, QuotaHttpError } from "../core/quota.js";
+import type { QuotaWindows } from "../types.js";
+import type { ToolAdapter, ToolCredential } from "./types.js";
 
 const BASE_SHARED_LINK_SKIP = new Set([".claude.json", "image-cache", "statsig", "plugins"]);
+
+// Undocumented endpoint that backs Claude Code's own /usage view. Anonymous requests
+// are rejected with a flat one-hour Retry-After, so it is never called without a token.
+const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 
 function keychainService(args: { homeDir: string; configDir: string }): string {
   const primary = path.join(args.homeDir, ".claude");
@@ -37,6 +46,208 @@ async function readAccount(configDir: string): Promise<{ email: string; orgName?
   }
 }
 
+type OauthBlock = {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  refreshTokenExpiresAt?: number;
+  scopes?: string[];
+  subscriptionType?: string;
+  rateLimitTier?: string;
+};
+
+// The stored blob also carries unrelated state (mcpOAuth), so it is always read and
+// rewritten whole — only claudeAiOauth is replaced.
+type StoredCredentials = { claudeAiOauth?: OauthBlock } & Record<string, unknown>;
+
+function parseStored(raw: string): StoredCredentials | null {
+  try {
+    const parsed = JSON.parse(raw) as StoredCredentials;
+    return typeof parsed === "object" && parsed !== null ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function toCredential(stored: StoredCredentials | null): ToolCredential | null {
+  const oauth = stored?.claudeAiOauth;
+  if (!oauth?.accessToken) return null;
+  return {
+    accessToken: oauth.accessToken,
+    refreshToken: oauth.refreshToken,
+    expiresAt: oauth.expiresAt,
+  };
+}
+
+function runSecurity(args: string[]): Promise<{ code: number; stdout: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("security", args, { stdio: ["ignore", "pipe", "ignore"] });
+    let out = "";
+    child.stdout.on("data", (chunk) => {
+      out += chunk;
+    });
+    child.on("close", (code) => resolve({ code: code ?? 1, stdout: out }));
+    child.on("error", () => resolve({ code: 1, stdout: "" }));
+  });
+}
+
+async function readKeychainBlob(service: string): Promise<StoredCredentials | null> {
+  const { code, stdout } = await runSecurity(["find-generic-password", "-s", service, "-w"]);
+  return code === 0 ? parseStored(stdout) : null;
+}
+
+/**
+ * `security add-generic-password -U` keys on both service and account, so writing
+ * under a different account would add a second entry instead of replacing the entry
+ * Claude Code reads.
+ */
+async function keychainAccount(service: string): Promise<string> {
+  const { code, stdout } = await runSecurity(["find-generic-password", "-s", service]);
+  const match = code === 0 ? /"acct"<blob>="([^"]*)"/.exec(stdout) : null;
+  return match?.[1] || os.userInfo().username;
+}
+
+const credentialsFilePath = (configDir: string) => path.join(configDir, ".credentials.json");
+
+async function readFileBlob(configDir: string): Promise<StoredCredentials | null> {
+  try {
+    return parseStored(await readFile(credentialsFilePath(configDir), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function readStoredBlob(configDir: string): Promise<StoredCredentials | null> {
+  if (process.platform === "darwin") {
+    return readKeychainBlob(keychainService({ homeDir: process.env.HOME ?? "", configDir }));
+  }
+  return readFileBlob(configDir);
+}
+
+/**
+ * Persists the blob and reads it back. The read-back is not paranoia: a refresh has
+ * already invalidated the previous token by this point, so a write that silently did
+ * not land would leave the profile with no usable credential at all.
+ */
+async function writeStoredBlob(configDir: string, blob: StoredCredentials): Promise<void> {
+  const serialized = JSON.stringify(blob);
+
+  if (process.platform === "darwin") {
+    const service = keychainService({ homeDir: process.env.HOME ?? "", configDir });
+    const account = await keychainAccount(service);
+    const { code } = await runSecurity(["add-generic-password", "-U", "-s", service, "-a", account, "-w", serialized]);
+    if (code !== 0) throw new Error(`could not write Keychain item '${service}'`);
+
+    const readBack = await readKeychainBlob(service);
+    if (readBack?.claudeAiOauth?.accessToken !== blob.claudeAiOauth?.accessToken) {
+      throw new Error(`Keychain item '${service}' did not take the renewed credential`);
+    }
+    return;
+  }
+
+  const target = credentialsFilePath(configDir);
+  const tmpPath = `${target}.tmp.${process.pid}`;
+  await writeFile(tmpPath, serialized, { encoding: "utf8", mode: 0o600 });
+  await rename(tmpPath, target);
+
+  const readBack = await readFileBlob(configDir);
+  if (readBack?.claudeAiOauth?.accessToken !== blob.claudeAiOauth?.accessToken) {
+    throw new Error(`${target} did not take the renewed credential`);
+  }
+}
+
+/**
+ * macOS keeps the OAuth tokens in the Keychain, keyed by the same per-config-dir
+ * service name the rest of clausona already derives. Everywhere else Claude Code
+ * writes them next to the config as .credentials.json.
+ */
+async function readClaudeCredential(configDir: string): Promise<ToolCredential | null> {
+  return toCredential(await readStoredBlob(configDir));
+}
+
+async function fetchClaudeQuota(credential: ToolCredential, signal: AbortSignal): Promise<QuotaWindows | null> {
+  const response = await fetch(USAGE_URL, {
+    headers: {
+      Authorization: `Bearer ${credential.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new QuotaHttpError(response.status, response.headers.get("retry-after"));
+  }
+
+  return parseClaudeQuota(await response.json());
+}
+
+type RefreshResponse = {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  refresh_token_expires_in?: number;
+  scope?: string;
+};
+
+/**
+ * Renews via the OAuth refresh grant and stores the result.
+ *
+ * The provider rotates the refresh token and rejects the previous one immediately —
+ * there is no reuse window — so the response is persisted before this returns and any
+ * persistence failure is raised rather than swallowed.
+ */
+async function renewClaudeCredential(
+  configDir: string,
+  credential: ToolCredential,
+  signal: AbortSignal,
+): Promise<ToolCredential> {
+  if (!credential.refreshToken) {
+    throw new Error("no refresh token stored for this profile");
+  }
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: credential.refreshToken,
+      client_id: OAUTH_CLIENT_ID,
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    // The refresh token itself has lapsed or been revoked; only a fresh login helps.
+    throw new QuotaHttpError(response.status, response.headers.get("retry-after"));
+  }
+
+  const data = (await response.json()) as RefreshResponse;
+  if (!data.access_token) throw new Error("refresh response carried no access token");
+
+  // Re-read rather than reusing an earlier copy: another process may have rewritten
+  // unrelated parts of the blob (mcpOAuth) while the request was in flight.
+  const blob = (await readStoredBlob(configDir)) ?? {};
+  const previous = blob.claudeAiOauth ?? {};
+  const now = Date.now();
+
+  blob.claudeAiOauth = {
+    ...previous,
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? credential.refreshToken,
+    ...(data.expires_in ? { expiresAt: now + data.expires_in * 1000 } : {}),
+    ...(data.refresh_token_expires_in ? { refreshTokenExpiresAt: now + data.refresh_token_expires_in * 1000 } : {}),
+    ...(data.scope ? { scopes: data.scope.split(" ") } : {}),
+  };
+
+  await writeStoredBlob(configDir, blob);
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: blob.claudeAiOauth.refreshToken,
+    expiresAt: blob.claudeAiOauth.expiresAt,
+  };
+}
+
 async function runLoginInteractive(configDir: string): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const child = spawn("claude", ["auth", "login"], {
@@ -62,5 +273,8 @@ export const claudeAdapter: ToolAdapter = {
   // postSetup is left undefined here — service.ts's syncPluginsJson is wired into the
   // Claude code path explicitly because it has cross-cutting plugin marketplace state.
   // We will keep that wiring during Task 11 refactor; the adapter is not the place for it.
+  readCredential: readClaudeCredential,
+  fetchQuota: fetchClaudeQuota,
+  renewCredential: renewClaudeCredential,
   runLogin: runLoginInteractive,
 };

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -1,9 +1,11 @@
 import { spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { parseCodexQuota, QuotaHttpError } from "../core/quota.js";
+import type { QuotaWindows } from "../types.js";
 import { decodeJwtPayload } from "./codex-jwt.js";
-import type { AccountInfo, ToolAdapter } from "./types.js";
+import type { AccountInfo, ToolAdapter, ToolCredential } from "./types.js";
 
 // Files/dirs under $CODEX_HOME that are credential or per-account state and must not be shared.
 const BASE_SKIP = new Set([
@@ -81,6 +83,128 @@ async function readCodexAccount(configDir: string): Promise<AccountInfo | null> 
   return null;
 }
 
+const USAGE_URL = "https://chatgpt.com/backend-api/codex/usage";
+const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+// chatgpt.com serves a bot-check page to unrecognized clients, so the request has to
+// identify itself the way the Codex CLI does.
+const CODEX_ORIGINATOR = "codex_cli_rs";
+const CODEX_USER_AGENT = `${CODEX_ORIGINATOR}/clausona (${process.platform}; ${process.arch})`;
+
+type CodexTokens = {
+  id_token?: string;
+  access_token?: string;
+  refresh_token?: string;
+  account_id?: string;
+};
+
+// auth.json also holds auth_mode and OPENAI_API_KEY, so it is rewritten whole.
+type CodexAuth = { tokens?: CodexTokens; last_refresh?: string } & Record<string, unknown>;
+
+const authFilePath = (configDir: string) => path.join(configDir, "auth.json");
+
+async function readCodexAuth(configDir: string): Promise<CodexAuth | null> {
+  try {
+    const parsed = JSON.parse(await readFile(authFilePath(configDir), "utf8")) as CodexAuth;
+    return typeof parsed === "object" && parsed !== null ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function toCodexCredential(auth: CodexAuth | null): ToolCredential | null {
+  const accessToken = auth?.tokens?.access_token;
+  if (!accessToken) return null;
+
+  const expSeconds = decodeJwtPayload(accessToken)?.exp;
+  const accountId = auth?.tokens?.account_id;
+
+  return {
+    accessToken,
+    refreshToken: auth?.tokens?.refresh_token,
+    expiresAt: typeof expSeconds === "number" ? expSeconds * 1000 : undefined,
+    headers: accountId ? { "chatgpt-account-id": accountId } : undefined,
+  };
+}
+
+async function readCodexCredential(configDir: string): Promise<ToolCredential | null> {
+  return toCodexCredential(await readCodexAuth(configDir));
+}
+
+/**
+ * Renews via the OAuth refresh grant and stores the result before returning, for the
+ * same reason as the Claude adapter: the previous refresh token stops working the
+ * moment the provider answers.
+ */
+async function renewCodexCredential(
+  configDir: string,
+  credential: ToolCredential,
+  signal: AbortSignal,
+): Promise<ToolCredential> {
+  if (!credential.refreshToken) {
+    throw new Error("no refresh token stored for this profile");
+  }
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: credential.refreshToken,
+      client_id: OAUTH_CLIENT_ID,
+      scope: "openid profile email",
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new QuotaHttpError(response.status, response.headers.get("retry-after"));
+  }
+
+  const data = (await response.json()) as { access_token?: string; refresh_token?: string; id_token?: string };
+  if (!data.access_token) throw new Error("refresh response carried no access token");
+
+  const auth = (await readCodexAuth(configDir)) ?? {};
+  auth.tokens = {
+    ...auth.tokens,
+    access_token: data.access_token,
+    refresh_token: data.refresh_token ?? credential.refreshToken,
+    ...(data.id_token ? { id_token: data.id_token } : {}),
+  };
+  auth.last_refresh = new Date().toISOString();
+
+  const target = authFilePath(configDir);
+  const tmpPath = `${target}.tmp.${process.pid}`;
+  await writeFile(tmpPath, `${JSON.stringify(auth, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await rename(tmpPath, target);
+
+  const readBack = await readCodexAuth(configDir);
+  if (readBack?.tokens?.access_token !== data.access_token) {
+    throw new Error(`${target} did not take the renewed credential`);
+  }
+
+  return toCodexCredential(auth) ?? { accessToken: data.access_token };
+}
+
+async function fetchCodexQuota(credential: ToolCredential, signal: AbortSignal): Promise<QuotaWindows | null> {
+  const response = await fetch(USAGE_URL, {
+    headers: {
+      Authorization: `Bearer ${credential.accessToken}`,
+      "User-Agent": CODEX_USER_AGENT,
+      originator: CODEX_ORIGINATOR,
+      ...credential.headers,
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new QuotaHttpError(response.status, response.headers.get("retry-after"));
+  }
+
+  return parseCodexQuota(await response.json());
+}
+
 async function runCodexLogin(configDir: string): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const child = spawn("codex", ["login"], {
@@ -101,5 +225,8 @@ export const codexAdapter: ToolAdapter = {
   readAccountInfo: readCodexAccount,
   sharedSkipSet: buildSkipSet,
   shouldSkipName: (name, _mergeSessions) => SKIP_PREFIXES.some((p) => name.startsWith(p)),
+  readCredential: readCodexCredential,
+  fetchQuota: fetchCodexQuota,
+  renewCredential: renewCodexCredential,
   runLogin: runCodexLogin,
 };

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,8 +1,18 @@
-import type { ToolName } from "../types.js";
+import type { QuotaWindows, ToolName } from "../types.js";
 
 export type AccountInfo = {
   email: string;
   orgName?: string;
+};
+
+export type ToolCredential = {
+  accessToken: string;
+  /** Present when the stored credential can be renewed without a fresh login. */
+  refreshToken?: string;
+  /** ms epoch, when the credential format records one. */
+  expiresAt?: number;
+  /** Additional headers the tool's usage endpoint requires. */
+  headers?: Record<string, string>;
 };
 
 export type ToolAdapter = {
@@ -28,6 +38,22 @@ export type ToolAdapter = {
 
   // Per-tool post-link setup (e.g. Claude's plugins JSON path-rewrite).
   postSetup?(profileDir: string, primaryDir: string): Promise<void>;
+
+  // Reads the profile's OAuth access token. Null when the profile has no usable
+  // credential, which is the signal to skip the network entirely.
+  readCredential?(configDir: string): Promise<ToolCredential | null>;
+
+  // Fetches and normalizes the tool's quota endpoint. Only called with a credential
+  // from readCredential; throws QuotaHttpError for non-2xx responses.
+  fetchQuota?(credential: ToolCredential, signal: AbortSignal): Promise<QuotaWindows | null>;
+
+  // Exchanges the stored refresh token for a fresh credential AND persists it.
+  //
+  // Rotation has no grace period: the moment the provider answers, the old refresh
+  // token is dead. An implementation MUST therefore persist the response before it
+  // returns, and MUST throw if it cannot — a caller that sees a return value is
+  // entitled to assume the new credential survived the process.
+  renewCredential?(configDir: string, credential: ToolCredential, signal: AbortSignal): Promise<ToolCredential>;
 
   // Spawns the tool's interactive login with the given config dir as its env-var target.
   runLogin(configDir: string): Promise<boolean>;

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -34,6 +34,7 @@ vi.mock("../lib/service", () => ({
       issues: [],
     },
   ]),
+  fetchProfileQuotas: vi.fn(async () => ({})),
   initializeRegistry: vi.fn(async () => ({})),
   setActiveProfileByName: vi.fn(async () => ({})),
 }));

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -6,12 +6,13 @@ import TextInput from "ink-text-input";
 import { useEffect, useRef, useState } from "react";
 
 import { bootstrapInitFromCurrentState } from "../commands.js";
-import { formatCount, formatCurrency, localTimezoneLabel } from "../lib/format.js";
+import { formatCount, formatCurrency, formatQuotaInline, localTimezoneLabel, quotaSeverity } from "../lib/format.js";
 import { profileId } from "../lib/profile-ref.js";
 import {
   addProfile,
   discoverAccounts,
   doctorProfiles,
+  fetchProfileQuotas,
   initializeRegistry,
   listProfiles,
   loginProfile,
@@ -21,7 +22,7 @@ import {
   updateProfileConfig,
   validateConfigDir,
 } from "../lib/service.js";
-import type { DiscoveredAccount, DoctorProfileResult, ProfileListItem, ToolName } from "../types.js";
+import type { DiscoveredAccount, DoctorProfileResult, ProfileListItem, QuotaSnapshot, ToolName } from "../types.js";
 import { Chrome } from "./components/Chrome.js";
 import { Divider } from "./components/Divider.js";
 import { ProfilePreview } from "./components/ProfilePreview.js";
@@ -281,6 +282,23 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
   useEffect(() => {
     void refreshDashboard();
   }, []);
+
+  // Quota comes from the network, so it is fetched after the dashboard paints and
+  // merged in. Keyed on the profile set, not the array, so merging does not re-trigger.
+  const profileKey = profiles.map((p) => p.name).join("\u0000");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: profiles is read via profileKey to avoid a merge loop
+  useEffect(() => {
+    if (profiles.length === 0) return;
+    let cancelled = false;
+    void (async () => {
+      const quotas = await fetchProfileQuotas(profiles).catch((): Record<string, QuotaSnapshot> => ({}));
+      if (cancelled) return;
+      setProfiles((prev) => prev.map((p) => (quotas[p.name] ? { ...p, quota: quotas[p.name] } : p)));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [profileKey]);
 
   useEffect(() => {
     if (screen === "init") {
@@ -1393,6 +1411,8 @@ export function App({ initialScreen = "dashboard" }: AppProps) {
                 detail: p.email,
                 badge: p.isActive ? "active" : undefined,
                 badgeVariant: p.isActive ? ("active" as const) : undefined,
+                meta: formatQuotaInline(p.quota),
+                metaVariant: quotaSeverity(p.quota),
               }))}
               index={cursor}
             />

--- a/src/tui/components/ProfilePreview.tsx
+++ b/src/tui/components/ProfilePreview.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
-import { formatCurrency, localTimezoneLabel } from "../../lib/format.js";
-import type { DoctorProfileResult, ProfileListItem } from "../../types.js";
+import { truncate } from "../../lib/cli-style.js";
+import { formatAge, formatCurrency, formatQuotaPercent, formatResetIn, localTimezoneLabel } from "../../lib/format.js";
+import type { DoctorProfileResult, ProfileListItem, QuotaSnapshot, QuotaWindow } from "../../types.js";
 import { color, symbol } from "../theme.js";
 
 function Row({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) {
@@ -23,6 +24,74 @@ function Separator() {
         <Text color={color.dim}>{symbol.lineH.repeat(300)}</Text>
       </Box>
     </Box>
+  );
+}
+
+const EM_DASH = "\u2014";
+
+const QUOTA_CRITICAL = 90;
+const QUOTA_WARNING = 75;
+
+const QUOTA_STATE_NOTE: Record<Exclude<QuotaSnapshot["state"], "ok">, string> = {
+  expired: "sign-in lapsed \u2014 clausona login",
+  missing: "no stored credential",
+  cooldown: "rate limited, retrying later",
+  error: "lookup failed",
+};
+
+function quotaColor(window: QuotaWindow, live: boolean): string {
+  if (!live) return color.muted;
+  if (window.usedPercent >= QUOTA_CRITICAL) return color.error;
+  if (window.usedPercent >= QUOTA_WARNING) return color.warning;
+  return color.text;
+}
+
+/** A 10-cell bar reads faster than a number when scanning several accounts. */
+function bar(usedPercent: number): string {
+  const filled = Math.min(10, Math.max(0, Math.round(usedPercent / 10)));
+  return `${"\u2588".repeat(filled)}${"\u2591".repeat(10 - filled)}`;
+}
+
+function QuotaRow({ label, window, live }: { label: string; window?: QuotaWindow; live: boolean }) {
+  if (!window) {
+    return <Row label={label} value={EM_DASH} valueColor={color.muted} />;
+  }
+  const reset = formatResetIn(window.resetsAt);
+  const suffix = reset === EM_DASH ? "" : `  resets in ${reset}`;
+  return (
+    <Row
+      label={label}
+      value={`${bar(window.usedPercent)} ${formatQuotaPercent(window).padStart(4)}${suffix}`}
+      valueColor={quotaColor(window, live)}
+    />
+  );
+}
+
+function QuotaSection({ quota }: { quota?: QuotaSnapshot }) {
+  if (!quota) {
+    return <Row label="Quota" value="loading\u2026" valueColor={color.muted} />;
+  }
+
+  const live = quota.state === "ok";
+  const hasWindows = Boolean(quota.session ?? quota.weekly ?? quota.scoped);
+  return (
+    <>
+      <QuotaRow label="Session" window={quota.session} live={live} />
+      <QuotaRow label="Weekly" window={quota.weekly} live={live} />
+      {quota.scoped && <QuotaRow label={truncate(quota.scoped.label, 12)} window={quota.scoped} live={live} />}
+      {quota.state !== "ok" && (
+        <Row
+          label=""
+          // Numbers shown for a failed lookup are a last-known reading, so say how old.
+          value={
+            hasWindows
+              ? `${QUOTA_STATE_NOTE[quota.state]} \u00b7 ${formatAge(quota.fetchedAt)}`
+              : QUOTA_STATE_NOTE[quota.state]
+          }
+          valueColor={color.warning}
+        />
+      )}
+    </>
   );
 }
 
@@ -87,6 +156,13 @@ export function ProfilePreview({ profile, doctor }: { profile?: ProfileListItem;
             valueColor={profile.mergeSessions ? color.warning : color.secondary}
           />
         )}
+      </Box>
+
+      <Separator />
+
+      {/* Plan quota */}
+      <Box flexDirection="column" gap={0} marginBottom={1} flexShrink={0}>
+        <QuotaSection quota={profile.quota} />
       </Box>
 
       <Separator />

--- a/src/tui/components/ProfilePreview.tsx
+++ b/src/tui/components/ProfilePreview.tsx
@@ -1,17 +1,30 @@
 import { Box, Text } from "ink";
 import { truncate } from "../../lib/cli-style.js";
-import { formatAge, formatCurrency, formatQuotaPercent, formatResetIn, localTimezoneLabel } from "../../lib/format.js";
+import { fitQuotaValue, formatAge, formatCurrency, localTimezoneLabel } from "../../lib/format.js";
 import type { DoctorProfileResult, ProfileListItem, QuotaSnapshot, QuotaWindow } from "../../types.js";
 import { color, symbol } from "../theme.js";
 
-function Row({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) {
+function Row({
+  label,
+  value,
+  valueColor,
+  singleLine = false,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+  /** Keep the value on one line. Prevents character-by-character wrapping in a narrow panel. */
+  singleLine?: boolean;
+}) {
   return (
     <Box gap={1} width="100%" flexDirection="row">
       <Box width={12} flexShrink={0}>
         <Text color={color.muted}>{label}</Text>
       </Box>
-      <Box flexGrow={1} flexShrink={1}>
-        <Text color={valueColor ?? color.text}>{value}</Text>
+      <Box flexGrow={1} flexShrink={1} minWidth={0} overflow={singleLine ? "hidden" : undefined}>
+        <Text color={valueColor ?? color.text} wrap={singleLine ? "truncate-end" : undefined}>
+          {value}
+        </Text>
       </Box>
     </Box>
   );
@@ -46,30 +59,34 @@ function quotaColor(window: QuotaWindow, live: boolean): string {
   return color.text;
 }
 
-/** A 10-cell bar reads faster than a number when scanning several accounts. */
-function bar(usedPercent: number): string {
-  const filled = Math.min(10, Math.max(0, Math.round(usedPercent / 10)));
-  return `${"\u2588".repeat(filled)}${"\u2591".repeat(10 - filled)}`;
+// The detail panel is a fraction of the terminal, and ink gives no width back during
+// render, so the space a Row's value gets is derived from the same layout constants.
+const PREVIEW_PANEL_FRACTION = 0.45; // layout.previewPanelWidth
+const PANEL_CHROME = 10; // outer + inner borders and padding
+const LABEL_COLUMN = 13; // Row's label box plus its gap
+
+function valueWidth(columns: number): number {
+  return Math.max(0, Math.floor(columns * PREVIEW_PANEL_FRACTION) - PANEL_CHROME - LABEL_COLUMN);
 }
 
 function QuotaRow({ label, window, live }: { label: string; window?: QuotaWindow; live: boolean }) {
   if (!window) {
-    return <Row label={label} value={EM_DASH} valueColor={color.muted} />;
+    return <Row label={label} value={EM_DASH} valueColor={color.muted} singleLine />;
   }
-  const reset = formatResetIn(window.resetsAt);
-  const suffix = reset === EM_DASH ? "" : `  resets in ${reset}`;
+
   return (
     <Row
       label={label}
-      value={`${bar(window.usedPercent)} ${formatQuotaPercent(window).padStart(4)}${suffix}`}
+      value={fitQuotaValue(window, valueWidth(process.stdout.columns ?? 100))}
       valueColor={quotaColor(window, live)}
+      singleLine
     />
   );
 }
 
 function QuotaSection({ quota }: { quota?: QuotaSnapshot }) {
   if (!quota) {
-    return <Row label="Quota" value="loading\u2026" valueColor={color.muted} />;
+    return <Row label="Quota" value="loading\u2026" valueColor={color.muted} singleLine />;
   }
 
   const live = quota.state === "ok";
@@ -89,6 +106,7 @@ function QuotaSection({ quota }: { quota?: QuotaSnapshot }) {
               : QUOTA_STATE_NOTE[quota.state]
           }
           valueColor={color.warning}
+          singleLine
         />
       )}
     </>

--- a/src/tui/components/SelectList.tsx
+++ b/src/tui/components/SelectList.tsx
@@ -37,42 +37,52 @@ export function SelectList({
         const focused = i === index;
 
         return (
-          <Box key={item.id} gap={1}>
+          <Box key={item.id} gap={1} width="100%" flexWrap="nowrap">
             {/* Cursor */}
-            <Box width={2}>
+            <Box width={2} flexShrink={0}>
               <Text color={focused ? color.cursor : color.dim}>{focused ? symbol.cursor : " "}</Text>
             </Box>
 
             {/* Checkbox for multi */}
             {multi && (
-              <Box width={2}>
+              <Box width={2} flexShrink={0}>
                 <Text color={item.selected ? color.selected : color.dim}>
                   {item.selected ? symbol.checkboxOn : symbol.checkboxOff}
                 </Text>
               </Box>
             )}
 
-            <Box flexDirection="column">
-              {/* Label + Badge */}
-              <Box gap={1}>
-                <Text color={focused ? color.text : color.secondary} bold={focused}>
-                  {item.label}
-                </Text>
+            {/* minWidth={0} lets this column shrink below its content width, which is what
+                allows the label to truncate instead of wrapping into the badge and meta. */}
+            <Box flexDirection="column" flexGrow={1} flexShrink={1} minWidth={0} overflow="hidden">
+              {/* Label + Badge + Meta — one line, never wrapped */}
+              <Box gap={1} width="100%" flexWrap="nowrap" overflow="hidden">
+                <Box flexShrink={1} minWidth={0} overflow="hidden">
+                  <Text color={focused ? color.text : color.secondary} bold={focused} wrap="truncate-end">
+                    {item.label}
+                  </Text>
+                </Box>
 
                 {item.badge ? (
-                  <Text color={badgeColorMap[item.badgeVariant ?? "muted"] ?? color.muted}>
-                    {symbol.dot} {item.badge}
-                  </Text>
+                  <Box flexShrink={0}>
+                    <Text color={badgeColorMap[item.badgeVariant ?? "muted"] ?? color.muted} wrap="truncate-end">
+                      {symbol.dot} {item.badge}
+                    </Text>
+                  </Box>
                 ) : null}
 
                 {item.meta ? (
-                  <Text color={badgeColorMap[item.metaVariant ?? "muted"] ?? color.muted}>{item.meta}</Text>
+                  <Box flexShrink={0}>
+                    <Text color={badgeColorMap[item.metaVariant ?? "muted"] ?? color.muted} wrap="truncate-end">
+                      {item.meta}
+                    </Text>
+                  </Box>
                 ) : null}
               </Box>
 
               {/* Detail on its own line */}
               {item.detail ? (
-                <Text color={focused ? color.secondary : color.muted} wrap="wrap">
+                <Text color={focused ? color.secondary : color.muted} wrap="truncate-end">
                   {item.detail}
                 </Text>
               ) : null}

--- a/src/tui/components/SelectList.tsx
+++ b/src/tui/components/SelectList.tsx
@@ -8,6 +8,9 @@ export type SelectListItem = {
   selected?: boolean;
   badge?: string;
   badgeVariant?: "active" | "healthy" | "warning" | "error" | "muted" | "primary";
+  /** Short status text shown after the badge, coloured by metaVariant. */
+  meta?: string;
+  metaVariant?: "healthy" | "warning" | "error" | "muted";
 };
 
 const badgeColorMap: Record<string, string> = {
@@ -60,6 +63,10 @@ export function SelectList({
                   <Text color={badgeColorMap[item.badgeVariant ?? "muted"] ?? color.muted}>
                     {symbol.dot} {item.badge}
                   </Text>
+                ) : null}
+
+                {item.meta ? (
+                  <Text color={badgeColorMap[item.metaVariant ?? "muted"] ?? color.muted}>{item.meta}</Text>
                 ) : null}
               </Box>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,40 @@ export type UsageSummary = {
   outputTokens: number;
 };
 
+export type QuotaWindow = {
+  /** Consumed share of the window, 0-100. */
+  usedPercent: number;
+  /** ISO 8601 instant the window rolls over, or null when the API omits it. */
+  resetsAt: string | null;
+};
+
+export type QuotaWindows = {
+  /** Short rolling window: Claude's 5-hour session, Codex's sub-day window. */
+  session?: QuotaWindow;
+  /** Seven-day window. */
+  weekly?: QuotaWindow;
+  /** Most-consumed model-scoped weekly limit, when the tool reports one. */
+  scoped?: QuotaWindow & { label: string };
+};
+
+/**
+ * Anything other than `ok` means the numbers (if any) are a last-known reading rather
+ * than a current one; `fetchedAt` says how old they are.
+ *
+ * `ok`      - fetched just now, or cached and still within the freshness window
+ * `expired` - credential exists but the API rejected it (401/403)
+ * `missing` - no credential on disk for this profile
+ * `cooldown`- the endpoint returned 429; requests are paused until it lifts
+ * `error`   - network, timeout, or unparseable response
+ */
+export type QuotaState = "ok" | "expired" | "missing" | "cooldown" | "error";
+
+export type QuotaSnapshot = QuotaWindows & {
+  state: QuotaState;
+  /** ms epoch of the fetch that produced these windows. */
+  fetchedAt: number;
+};
+
 export type ToolName = "claude" | "codex";
 
 export type Profile = {
@@ -66,6 +100,7 @@ export type ProfileListItem = {
   isPrimary: boolean;
   isActive: boolean;
   mergeSessions?: boolean;
+  quota?: QuotaSnapshot;
   today: UsageSummary;
   week: UsageSummary;
   month: UsageSummary;


### PR DESCRIPTION
Closes #10.

Shows each account's plan-limit usage in `clausona list` and in the dashboard, so you can tell which profile still has headroom without switching into it first.

```
    PROFILE             ACCOUNT                      5H     7D     COST        INPUT
    claude:default      you@work.com                 23%    49%    $20947.44   45,158,790
    claude:personal     you@personal.com             —      —      —           —
  ▸ claude:side         you@side.com                 15%    4%     $44758.93   92,637,244
    claude:shared       team@work.com                0%     100%   $50822.21   93,968,776
  ▸ codex:work          you@work.com                 —      0%     —           —  *
  expired: sign-in has lapsed — run `clausona login <profile>`
```

Percentages are coloured by severity (≥90% red, ≥75% amber). The TUI shows the same reading inline in the profile picker, and gauges with reset times plus the most-consumed per-model limit in the detail panel:

```
  ✦  claude:default 5h 23% | 7d 49%      Session   ██░░░░░░░░  23%  resets in 39m
     claude:shared 5h 0% | 7d 100%       Weekly    █████░░░░░  49%  resets in 13h 19m
     claude:side expired                 Fable     ████████░░  77%  resets in 13h 19m
```

## How

Readings come from each tool's own usage endpoint, authenticated with the credential that tool already stored for the profile — nothing new is asked for or kept:

| Tool | Endpoint | Credential |
| --- | --- | --- |
| Claude | `GET api.anthropic.com/api/oauth/usage` | macOS Keychain (existing per-config-dir service name), else `<configDir>/.credentials.json` |
| Codex | `GET chatgpt.com/backend-api/codex/usage` | `<configDir>/auth.json` |

New modules:

- `src/core/quota.ts` — response parsing and cache policy, all pure and unit-tested against payloads captured from live responses
- `src/core/quota-store.ts` — cache, cooldown, renewal orchestration, per-profile locking

Existing seams did most of the work: quota lookup is an optional `ToolAdapter` capability (`readCredential` / `fetchQuota` / `renewCredential`), and the Keychain service name per config dir already existed in `src/core/paths.ts`.

## Endpoint behaviours the design accounts for

Both were measured, not assumed.

**Anonymous requests to the Claude endpoint always 429**, with a flat `Retry-After: 3600`; the identical request succeeds from the same IP as soon as a token is attached. So a request is never issued without a credential — no credential, or one known to be lapsed, short-circuits before the network. A 429 parks the whole tool until the window lifts rather than being retried, because the limit is per-IP and trying another profile's token would only extend it.

**Access tokens last 8 hours**, so a profile you have not used today would report nothing — precisely the profile you most want to check. It is renewed on demand from the refresh token (~14 days) instead, which means every account used in the last two weeks reports its quota.

The renewal path is the sharp edge here, and it is worth reviewing closely: **the refresh token rotates with no reuse window.** Verified — the previous token is rejected with `invalid_grant` immediately after a successful refresh. Consequences, all enforced in code:

- The renewed credential is written *and read back* before `renewCredential` returns. A write that cannot be verified raises rather than falling back silently, because by then the old token is already dead.
- The credential store is re-read immediately before the merge, so unrelated contents (Claude's `mcpOAuth` block, Codex's `auth_mode`) survive a concurrent writer.
- Renewal is locked per profile, so two clausona processes cannot both rotate the same credential and leave one holding an invalidated token.
- At most one renewal per lookup, so a profile whose refresh token is also dead cannot spin.

Renewal is lazy — only once a token has actually lapsed, or if the endpoint rejects one that still looked valid by the clock (revoked elsewhere, or skew). Each profile therefore rotates at most once per 8 hours regardless of how often `clausona list` runs. `--no-renew` disables it.

## Degradation

`clausona list` was previously a purely local command, so failure handling matters more than the happy path. Nothing here can fail the listing: every lookup resolves to a state, never an exception, and a failed lookup keeps the last known numbers on screen — dimmed and stamped with their age — rather than blanking the row.

| State | Meaning |
| --- | --- |
| `expired` | Sign-in lapsed past renewal (refresh token >14 days, or revoked) → `clausona login <profile>` |
| `missing` | No credential stored for the profile |
| `cooldown` | Endpoint returned 429; that tool is parked until the window lifts |
| `error` | Network failure, 5s timeout, or an unreadable response |

These are undocumented internal endpoints, so responses are parsed defensively and an unrecognised shape degrades to `—` instead of throwing.

## Cost

| | |
| --- | --- |
| Cold (9 profiles, 6 network calls, parallel) | 2.3s |
| Warm (5-minute cache) | 0.22s |
| `--no-quota` | 0.26s — unchanged from before |
| While a tool is in cooldown | 0.27s, zero requests |

`--no-quota` keeps the command fully offline for scripting. The TUI paints the profile list first and merges quota in when it arrives, so nothing blocks on the network.

## Verification

`pnpm lint`, `tsc --noEmit`, 110 tests, `pnpm build` all pass. 34 of the tests are new.

Exercised against 9 real profiles across both tools, including the paths that are easy to get wrong:

- **Renewal happy path** — forced a live profile's `expiresAt` into the past (tokens untouched); renewal fired, both access and refresh tokens rotated, `expiresAt` moved +8h, `mcpOAuth` was preserved, the Keychain still held exactly one entry, and the profile returned live quota instead of `—`. The Keychain write mechanism itself was proven first on a throwaway entry — that `-U` updates in place rather than duplicating, preserves unrelated keys, and reads back identical.
- **Renewal failure** — two Codex profiles with 3-month-old refresh tokens; renewal failed and `auth.json` was left byte-identical, mtime included.
- **Cooldown** — seeded a cooldown and confirmed zero requests, cached numbers retained, reason surfaced.
- **Lock** — concurrent renewals of the same profile hold `maxInFlight === 1`; the loser backs off instead of rotating anyway.

Two bugs were found by the tests during development and are fixed here: a shallow `{ ...EMPTY_CACHE }` that had every caller mutating the same module-level maps (would have leaked entries and cooldowns between the TUI's repeated calls), and an unreachable `stale` state that has been removed in favour of surfacing the reading's age.

## Note for #9

This overlaps [#9 (Windows support)](https://github.com/larcane97/clausona/pull/9) in `src/tools/claude.ts`, `src/lib/service.ts`, `src/commands.ts` and `README.md`. Whichever lands second should adopt the other's conventions — this branch uses raw `spawn` and `process.env.HOME`, where #9 moves to `spawnCommand` and `homedir()`. The credential read/write in `claude.ts` is also platform-branched (`darwin` → Keychain, otherwise `.credentials.json`) and would want #9's Windows path applied. Happy to rebase onto #9 if it goes first.

## Docs

README gains a Plan quota section covering the columns, the renewal contract, and the failure states. The Data Storage section's "All data stays local on your machine" was also corrected — still true of storage and there is still no telemetry, but the quota lookup does send each profile's own credential to that profile's own provider endpoint, which the README now says.
