### PR TITLE
fix: share background session and team records across claude profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ When you register a new profile, clausona symlinks shared resources from your pr
 ~/.claude-work/            (new claude profile)
 ├── .claude.json           ← own auth credentials (NOT shared)
 ├── projects/              ← own session history (NOT shared by default)
+├── jobs/                  ← own background sessions (follows projects/)
+├── teams/                 ← own team records (follows projects/)
 ├── mcp-servers/  →  ~/.claude/mcp-servers    (symlink to primary)
 ├── plugins/      →  ~/.claude/plugins        (symlink to primary)
 ├── settings.json →  ~/.claude/settings.json  (symlink to primary)
@@ -212,6 +214,19 @@ otherwise fall back to same-volume hard links. If a profile is imported from ano
 clausona can create file symbolic links across volumes.
 
 **Session separation** is the default: each profile keeps its own session directory, so `/resume` (Claude) and `codex resume` (Codex) only show that profile's conversations. To share session history across claude profiles, pass `--merge-sessions` when adding or initializing.
+
+For claude profiles this covers background sessions and team records too. A background
+session is stored as a record in `jobs/` keyed by the same session id as its transcript
+under `projects/`, so the two are shared or separated together — sharing one without the
+other would leave a record whose transcript cannot be resumed. `clausona repair` folds a
+profile's own records into the primary before re-linking, so nothing is lost when a
+profile switches to shared sessions or has its links rebuilt.
+
+Shared links are created from the primary's contents at the time a profile is set up, so
+a directory the tool introduces in a later version does not reach profiles that already
+exist — the tool creates it locally instead, and the accounts silently stop sharing that
+state. `clausona doctor` reports these as `missing_shared_link`; `clausona repair
+<profile>` links them.
 
 ### Data Storage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clausona",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-beta",
   "private": true,
   "description": "Switch between multiple Claude Code and OpenAI Codex CLI accounts on one machine",
   "type": "module",

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -1,19 +1,31 @@
 import { describe, expect, it } from "vitest";
-
 import { evaluateSymlinkHealth } from "./doctor.js";
 
 describe("evaluateSymlinkHealth", () => {
-  it("reports broken links and local overrides for non-primary profiles", () => {
+  it("reports a local override where primary has the item", () => {
     const issues = evaluateSymlinkHealth({
       isPrimary: false,
-      items: [
-        { name: "cache", isSharedLink: true, pointsToPrimary: true, targetExists: false, existsInPrimary: true },
-        { name: "statsig", isSharedLink: false, pointsToPrimary: false, targetExists: true, existsInPrimary: true },
-      ],
+      items: [{ name: "jobs", isSharedLink: false, pointsToPrimary: false, targetExists: true, existsInPrimary: true }],
     });
+    expect(issues).toEqual([{ kind: "local_override", message: "jobs replaced an expected shared link" }]);
+  });
 
-    expect(issues).toHaveLength(2);
-    expect(issues[0]?.kind).toBe("broken_symlink");
-    expect(issues[1]?.kind).toBe("local_override");
+  it("reports a directory the primary has but the profile is missing", () => {
+    const issues = evaluateSymlinkHealth({
+      isPrimary: false,
+      items: [],
+      missingSharedDirs: ["jobs", "teams"],
+    });
+    expect(issues.map((i) => i.kind)).toEqual(["missing_shared_link", "missing_shared_link"]);
+    expect(issues[0].message).toContain("jobs/");
+    expect(issues[0].message).toContain("clausona repair");
+  });
+
+  it("stays silent for the primary profile even when directories are reported missing", () => {
+    expect(evaluateSymlinkHealth({ isPrimary: true, items: [], missingSharedDirs: ["jobs"] })).toEqual([]);
+  });
+
+  it("treats an absent missingSharedDirs as no missing directories", () => {
+    expect(evaluateSymlinkHealth({ isPrimary: false, items: [] })).toEqual([]);
   });
 });

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -3,6 +3,7 @@ import type { DoctorIssue } from "../types.js";
 export function evaluateSymlinkHealth({
   isPrimary,
   items,
+  missingSharedDirs = [],
 }: {
   isPrimary: boolean;
   items: Array<{
@@ -12,6 +13,20 @@ export function evaluateSymlinkHealth({
     targetExists: boolean;
     existsInPrimary: boolean;
   }>;
+  /**
+   * Directories that exist in the primary config dir but are absent from this
+   * profile. Shared links are only ever created from a snapshot of the primary
+   * taken when the profile was set up, so anything the tool adds in a later
+   * version never reaches an existing profile — the tool then creates it locally
+   * and the two accounts silently stop sharing that state.
+   *
+   * Only directories are reported. Files in the primary are dominated by
+   * transient state (`*.tmp.*`, `settings.json.bak.*`) that no profile is ever
+   * expected to carry, and a file's shared link is replaced by a real file the
+   * first time the tool writes it atomically — so file-level gaps are noise,
+   * while a missing directory is always a real sharing gap.
+   */
+  missingSharedDirs?: string[];
 }): DoctorIssue[] {
   if (isPrimary) {
     return [];
@@ -33,6 +48,13 @@ export function evaluateSymlinkHealth({
         message: `${item.name} replaced an expected shared link`,
       });
     }
+  }
+
+  for (const name of missingSharedDirs) {
+    issues.push({
+      kind: "missing_shared_link",
+      message: `${name}/ is shared in primary but missing here — run 'clausona repair'`,
+    });
   }
 
   return issues;

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -165,6 +165,76 @@ async function mergeSessionFiles(sourceDir: string, primarySource: string) {
   return merged;
 }
 
+/**
+ * Move session-keyed record directories (`jobs/`, `teams/`) into the primary.
+ *
+ * Unlike `projects/`, these hold one self-contained directory per session id and no
+ * index to rebuild, so a merge is a plain per-record move. Records are addressed by the
+ * session id (`jobs/` uses its first 8 characters), which makes collisions across
+ * accounts effectively impossible; where one does occur the primary's copy wins rather
+ * than being overwritten.
+ */
+async function mergeRecordDirs(sourceDir: string, primarySource: string, kind: "jobs" | "teams") {
+  const src = path.join(sourceDir, kind);
+  const dst = path.join(primarySource, kind);
+
+  const srcStats = await lstat(src).catch(() => null);
+  if (!srcStats || srcStats.isSymbolicLink()) return 0;
+  if (!(await exists(dst))) return 0;
+
+  const entries = await readdir(src, { withFileTypes: true });
+  let merged = 0;
+
+  for (const entry of entries) {
+    // Loose files at this level (jobs/pins.json) are whole-store state, not records;
+    // merging them would mean merging their contents, so the primary's copy stands.
+    if (!entry.isDirectory()) continue;
+
+    const target = path.join(dst, entry.name);
+    if (await exists(target)) continue;
+    try {
+      await cp(path.join(src, entry.name), target, { recursive: true });
+      if (kind === "jobs") await rebaseJobTranscriptPath(target, sourceDir, primarySource);
+      merged++;
+    } catch (e) {
+      warn(`mergeRecordDirs(${kind}): could not copy ${entry.name}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * A job record stores the absolute path of its transcript, written against the config
+ * dir it was created under. That path still resolves while the profile exists — its
+ * `projects/` is a shared link to the primary — but it breaks the moment the profile
+ * directory goes away, so the merged copy is rebased onto the primary.
+ */
+async function rebaseJobTranscriptPath(jobDir: string, sourceDir: string, primarySource: string) {
+  const statePath = path.join(jobDir, "state.json");
+  const state = await readJson<Record<string, unknown>>(statePath, {});
+  const recorded = state.linkScanPath;
+  if (typeof recorded !== "string") return;
+
+  const prefix = sourceDir.endsWith(path.sep) ? sourceDir : sourceDir + path.sep;
+  if (!recorded.startsWith(prefix)) return;
+
+  state.linkScanPath = path.join(primarySource, recorded.slice(prefix.length));
+  await writeJson(statePath, state);
+}
+
+/**
+ * Fold a profile's own session state into the primary ahead of replacing it with shared
+ * links. `setupSharedLinks` backs a local directory up and then deletes it, and a
+ * backup under ~/.clausona is invisible to the tool — so anything not merged here is
+ * gone from the user's session and background lists.
+ */
+export async function mergeSessionState(sourceDir: string, primarySource: string) {
+  await mergeSessionFiles(sourceDir, primarySource);
+  await mergeRecordDirs(sourceDir, primarySource, "jobs");
+  await mergeRecordDirs(sourceDir, primarySource, "teams");
+}
+
 export async function setupSharedLinks(
   adapter: ToolAdapter,
   profileDir: string,
@@ -638,7 +708,7 @@ export async function initializeRegistry(options: {
         throw new Error(`primarySource for ${account.tool} not set — registry build invariant violated`);
       }
       if (merge && account.tool === "claude") {
-        await mergeSessionFiles(account.configDir, primary);
+        await mergeSessionState(account.configDir, primary);
       }
       await setupSharedLinks(adapter, account.configDir, primary, merge, backupDir);
       if (account.tool === "claude") {
@@ -813,9 +883,8 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
     }
 
     if (primarySource) {
-      const primaryEntries = new Set(
-        (await readdir(primarySource, { withFileTypes: true }).catch(() => [])).map((entry) => entry.name),
-      );
+      const primaryDirents = await readdir(primarySource, { withFileTypes: true }).catch(() => []);
+      const primaryEntries = new Set(primaryDirents.map((entry) => entry.name));
 
       const dirEntries = await readdir(profile.configDir, { withFileTypes: true }).catch(() => []);
       const isSkipped = (n: string) => shouldSkipShare(adapter, n, profile.mergeSessions ?? false);
@@ -858,10 +927,24 @@ export async function doctorProfiles(): Promise<DoctorProfileResult[]> {
         });
       }
 
+      // The loop above can only see what the profile already has, so a directory the
+      // primary gained after this profile was set up is invisible to it — the case that
+      // let split background-session state read as healthy. Walk the primary too.
+      const missingSharedDirs: string[] = [];
+      if (!profile.isPrimary) {
+        for (const entry of primaryDirents) {
+          if (!entry.isDirectory()) continue;
+          if (isSkipped(entry.name)) continue;
+          if (await exists(path.join(profile.configDir, entry.name))) continue;
+          missingSharedDirs.push(entry.name);
+        }
+      }
+
       issues.push(
         ...evaluateSymlinkHealth({
           isPrimary: Boolean(profile.isPrimary),
           items: sharedLinkItems,
+          missingSharedDirs,
         }),
       );
     }
@@ -938,13 +1021,16 @@ export async function repairProfile(id: string) {
   const backupDir = backupDirFor(CLAUSONA_DIR, profile.tool, name);
   const profileAdapter = getAdapter(profile.tool);
   const primarySource = registry.primarySources[profile.tool] ?? profileAdapter.defaultConfigDir(homedir());
-  const repaired = await setupSharedLinks(
-    profileAdapter,
-    profile.configDir,
-    primarySource,
-    profile.mergeSessions ?? false,
-    backupDir,
-  );
+  const mergeSessions = profile.mergeSessions ?? false;
+
+  // A profile that shares sessions may hold session state the primary has never seen —
+  // that is the whole point of repairing a profile whose links predate a directory the
+  // tool added later. Fold it in before setupSharedLinks deletes it.
+  if (mergeSessions && profile.tool === "claude") {
+    await mergeSessionState(profile.configDir, primarySource);
+  }
+
+  const repaired = await setupSharedLinks(profileAdapter, profile.configDir, primarySource, mergeSessions, backupDir);
   if (profile.tool === "claude") {
     await setupPluginsDir(profile.configDir, primarySource);
   }
@@ -952,7 +1038,7 @@ export async function repairProfile(id: string) {
   // Restore skip-set items from backup if they were stale symlinks that got removed
   // Skip if the backup item is a symlink pointing to primary (stale)
   if (await exists(backupDir)) {
-    const skipSet = profileAdapter.sharedSkipSet(profile.mergeSessions ?? false);
+    const skipSet = profileAdapter.sharedSkipSet(mergeSessions);
     for (const itemName of skipSet) {
       const target = path.join(profile.configDir, itemName);
       const backupItem = path.join(backupDir, itemName);
@@ -988,7 +1074,7 @@ export async function updateProfileConfig(id: string, options: { mergeSessions: 
 
   // separated → merged: merge session files before symlinking
   if (next && profile.tool === "claude") {
-    await mergeSessionFiles(profile.configDir, primarySource);
+    await mergeSessionState(profile.configDir, primarySource);
   }
 
   profile.mergeSessions = next;
@@ -1094,7 +1180,7 @@ export async function addProfile(options: {
     const mergeSessions = options.mergeSessions ?? false;
     try {
       if (mergeSessions && options.tool === "claude") {
-        await mergeSessionFiles(configDir, primarySource);
+        await mergeSessionState(configDir, primarySource);
       }
       await setupSharedLinks(adapter, configDir, primarySource, mergeSessions, backupDir);
       if (options.tool === "claude") {

--- a/src/lib/session-state.integration.test.ts
+++ b/src/lib/session-state.integration.test.ts
@@ -1,0 +1,201 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { claudeAdapter } from "../tools/claude.js";
+import { mergeSessionState, setupSharedLinks } from "./service.js";
+
+const temps: string[] = [];
+function scratch(label: string) {
+  const dir = mkdtempSync(path.join(tmpdir(), `clausona-${label}-`));
+  temps.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of temps.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function seedJob(configDir: string, id: string, sessionId: string) {
+  const jobDir = path.join(configDir, "jobs", id);
+  mkdirSync(jobDir, { recursive: true });
+  writeFileSync(
+    path.join(jobDir, "state.json"),
+    JSON.stringify({
+      state: "stopped",
+      sessionId,
+      resumeSessionId: sessionId,
+      daemonShort: id,
+      linkScanPath: path.join(configDir, "projects", "-repo", `${sessionId}.jsonl`),
+    }),
+  );
+  writeFileSync(path.join(jobDir, "timeline.jsonl"), '{"state":"stopped"}\n');
+  return jobDir;
+}
+
+function readState(configDir: string, id: string) {
+  return JSON.parse(readFileSync(path.join(configDir, "jobs", id, "state.json"), "utf8"));
+}
+
+describe("session-scoped skip set", () => {
+  it("keeps jobs/ and teams/ private when sessions are separated", () => {
+    const skip = claudeAdapter.sharedSkipSet(false);
+    expect(skip.has("projects")).toBe(true);
+    expect(skip.has("jobs")).toBe(true);
+    expect(skip.has("teams")).toBe(true);
+  });
+
+  it("shares jobs/ and teams/ when sessions are merged", () => {
+    const skip = claudeAdapter.sharedSkipSet(true);
+    expect(skip.has("projects")).toBe(false);
+    expect(skip.has("jobs")).toBe(false);
+    expect(skip.has("teams")).toBe(false);
+  });
+
+  it("links jobs/ and teams/ only for a session-merging profile", async () => {
+    const tmp = scratch("skip");
+    const primary = path.join(tmp, "primary");
+    const merged = path.join(tmp, "merged");
+    const separated = path.join(tmp, "separated");
+    for (const dir of [primary, merged, separated]) mkdirSync(dir, { recursive: true });
+    for (const name of ["projects", "jobs", "teams"]) mkdirSync(path.join(primary, name));
+
+    await setupSharedLinks(claudeAdapter, merged, primary, true, path.join(tmp, "b1"));
+    await setupSharedLinks(claudeAdapter, separated, primary, false, path.join(tmp, "b2"));
+
+    for (const name of ["projects", "jobs", "teams"]) {
+      expect(lstatSync(path.join(merged, name)).isSymbolicLink()).toBe(true);
+      expect(existsSync(path.join(separated, name))).toBe(false);
+    }
+  });
+});
+
+describe("mergeSessionState", () => {
+  it("moves background-session and team records into the primary", async () => {
+    const tmp = scratch("merge");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(path.join(primary, "jobs"), { recursive: true });
+    mkdirSync(path.join(primary, "teams"), { recursive: true });
+    mkdirSync(path.join(profile, "teams", "session-abcd1234"), { recursive: true });
+    writeFileSync(path.join(profile, "teams", "session-abcd1234", "config.json"), "{}");
+    seedJob(profile, "deadbeef", "deadbeef-1111-2222-3333-444455556666");
+
+    await mergeSessionState(profile, primary);
+
+    expect(existsSync(path.join(primary, "jobs", "deadbeef", "state.json"))).toBe(true);
+    expect(existsSync(path.join(primary, "jobs", "deadbeef", "timeline.jsonl"))).toBe(true);
+    expect(existsSync(path.join(primary, "teams", "session-abcd1234", "config.json"))).toBe(true);
+  });
+
+  it("rebases a merged job's transcript path onto the primary", async () => {
+    const tmp = scratch("rebase");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(path.join(primary, "jobs"), { recursive: true });
+    const sessionId = "deadbeef-1111-2222-3333-444455556666";
+    seedJob(profile, "deadbeef", sessionId);
+
+    await mergeSessionState(profile, primary);
+
+    expect(readState(primary, "deadbeef").linkScanPath).toBe(
+      path.join(primary, "projects", "-repo", `${sessionId}.jsonl`),
+    );
+  });
+
+  it("leaves a transcript path that does not belong to the profile untouched", async () => {
+    const tmp = scratch("foreign");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(path.join(primary, "jobs"), { recursive: true });
+    const jobDir = seedJob(profile, "deadbeef", "deadbeef-1111-2222-3333-444455556666");
+    const foreign = path.join(tmp, "elsewhere", "transcript.jsonl");
+    writeFileSync(path.join(jobDir, "state.json"), JSON.stringify({ linkScanPath: foreign }));
+
+    await mergeSessionState(profile, primary);
+
+    expect(readState(primary, "deadbeef").linkScanPath).toBe(foreign);
+  });
+
+  it("keeps the primary's record when both accounts hold the same id", async () => {
+    const tmp = scratch("collide");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(path.join(primary, "jobs"), { recursive: true });
+    seedJob(primary, "deadbeef", "primary-session");
+    seedJob(profile, "deadbeef", "profile-session");
+
+    await mergeSessionState(profile, primary);
+
+    expect(readState(primary, "deadbeef").sessionId).toBe("primary-session");
+  });
+
+  it("does not copy whole-store files such as jobs/pins.json", async () => {
+    const tmp = scratch("pins");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(path.join(primary, "jobs"), { recursive: true });
+    mkdirSync(path.join(profile, "jobs"), { recursive: true });
+    writeFileSync(path.join(primary, "jobs", "pins.json"), "[]");
+    writeFileSync(path.join(profile, "jobs", "pins.json"), '["profile"]');
+
+    await mergeSessionState(profile, primary);
+
+    expect(readFileSync(path.join(primary, "jobs", "pins.json"), "utf8")).toBe("[]");
+  });
+
+  it("is a no-op once the profile's records are already shared", async () => {
+    const tmp = scratch("shared");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(path.join(primary, "jobs"), { recursive: true });
+    mkdirSync(profile, { recursive: true });
+    seedJob(primary, "deadbeef", "primary-session");
+    symlinkSync(path.join(primary, "jobs"), path.join(profile, "jobs"));
+
+    await mergeSessionState(profile, primary);
+
+    expect(readState(primary, "deadbeef").sessionId).toBe("primary-session");
+    expect(lstatSync(path.join(profile, "jobs")).isSymbolicLink()).toBe(true);
+  });
+
+  it("leaves records alone when the primary has no store to merge into", async () => {
+    const tmp = scratch("nostore");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(primary, { recursive: true });
+    seedJob(profile, "deadbeef", "deadbeef-1111-2222-3333-444455556666");
+
+    await mergeSessionState(profile, primary);
+
+    expect(existsSync(path.join(primary, "jobs"))).toBe(false);
+    expect(existsSync(path.join(profile, "jobs", "deadbeef", "state.json"))).toBe(true);
+  });
+});
+
+describe("repair ordering", () => {
+  it("preserves records that setupSharedLinks would otherwise delete", async () => {
+    const tmp = scratch("order");
+    const primary = path.join(tmp, "primary");
+    const profile = path.join(tmp, "profile");
+    mkdirSync(path.join(primary, "jobs"), { recursive: true });
+    mkdirSync(path.join(primary, "projects"), { recursive: true });
+    seedJob(profile, "deadbeef", "deadbeef-1111-2222-3333-444455556666");
+
+    // The order repairProfile uses: fold session state in, then replace with links.
+    await mergeSessionState(profile, primary);
+    await setupSharedLinks(claudeAdapter, profile, primary, true, path.join(tmp, "backup"));
+
+    expect(lstatSync(path.join(profile, "jobs")).isSymbolicLink()).toBe(true);
+    // Reachable through the profile again, because it now lives in the primary.
+    expect(existsSync(path.join(profile, "jobs", "deadbeef", "state.json"))).toBe(true);
+  });
+});

--- a/src/tools/claude.ts
+++ b/src/tools/claude.ts
@@ -11,6 +11,14 @@ import type { ToolAdapter, ToolCredential } from "./types.js";
 
 const BASE_SHARED_LINK_SKIP = new Set([".claude.json", "image-cache", "statsig", "plugins"]);
 
+// State keyed by session id. `jobs/` holds the background-session records that the
+// background list reads (state, respawn flags, resume target) and `teams/` holds team
+// membership; both are addressed by the same session id as the transcripts under
+// `projects/`, and the tool derives all three from one CLAUDE_CONFIG_DIR. Sharing them
+// out of step with `projects/` splits a record from its transcript and resume breaks,
+// so they follow the session-separation choice rather than being shared unconditionally.
+const SESSION_SCOPED = ["projects", "jobs", "teams"] as const;
+
 // Undocumented endpoint that backs Claude Code's own /usage view. Anonymous requests
 // are rejected with a flat one-hour Retry-After, so it is never called without a token.
 const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
@@ -271,7 +279,7 @@ export const claudeAdapter: ToolAdapter = {
   keychainServiceName: keychainService,
   hasKeychainCredential: hasKeychain,
   sharedSkipSet: (mergeSessions) =>
-    mergeSessions ? new Set(BASE_SHARED_LINK_SKIP) : new Set([...BASE_SHARED_LINK_SKIP, "projects"]),
+    mergeSessions ? new Set(BASE_SHARED_LINK_SKIP) : new Set([...BASE_SHARED_LINK_SKIP, ...SESSION_SCOPED]),
   // postSetup is left undefined here — service.ts's syncPluginsJson is wired into the
   // Claude code path explicitly because it has cross-cutting plugin marketplace state.
   // We will keep that wiring during Task 11 refactor; the adapter is not the place for it.

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,7 @@ export type DoctorIssue = {
     | "broken_symlink"
     | "local_override"
     | "stale_symlink"
+    | "missing_shared_link"
     | "plugins_out_of_sync";
   message: string;
 };


### PR DESCRIPTION
Fixes #12.

## What was wrong

`setupSharedLinks` links the top-level entries present in the primary config dir **at the
moment a profile is set up**, and nothing re-runs it — `clausona use` only sets the env
var. Claude Code derives its state directories from one `CLAUDE_CONFIG_DIR`:

```js
function Sc()  { return join(be(), "projects") }   // transcripts
function Xvn() { return join(be(), "jobs") }        // background-session records
function T_e() { return join(be(), "teams") }       // team records
```

`teams/` and `jobs/` arrived in later Claude Code versions, so profiles created earlier
never got a link and Claude Code created them locally instead — one private copy per
account. Transcripts under `projects/` stayed shared, which is why the failure looked
partial: the process showed up, but the session was missing from the background list and
could not be resumed.

## What changed

**`jobs/` and `teams/` follow the session-separation choice** (`src/tools/claude.ts`).
They are keyed by the same session id as the transcripts, so sharing them out of step
with `projects/` would leave a record whose transcript cannot be resumed — exactly what
would happen to a profile added without `--merge-sessions` if they were shared
unconditionally.

**Records are folded into the primary before they are replaced by links**
(`mergeSessionState` in `src/lib/service.ts`, now also called from `repairProfile`).
Without this, repair backs the local store up under `~/.clausona`, where Claude Code
cannot see it, and the records disappear from the user's background list. Unlike
`projects/` there is no index to rebuild, so the merge is a per-record move; on a
collision the primary's copy wins. A job's recorded transcript path is rebased onto the
primary, because it only resolves through the profile's own `projects/` link and breaks
once the profile is gone.

**`doctor` walks the primary too** (`src/core/doctor.ts`, `doctorProfiles`). It could
previously only see what a profile already had, so a directory the primary gained later
was invisible and a profile missing `jobs/`, `teams/` and `daemon/` entirely reported
`healthy`. Only directories are reported — files in the primary are mostly transient
(`*.tmp.*`, `settings.json.bak.*`), and a file's shared link is replaced by a real file
the first time the tool writes it atomically, so file-level gaps are noise.

## Verification

15 new tests (4 unit, 11 integration) cover the skip set, the merge, path rebasing,
collisions, the `jobs/pins.json` whole-store file, the already-shared no-op, an absent
primary store, and the repair ordering that the fix depends on. Full suite: 155 passed.

Rehearsed against the reporting machine's own profiles, with the sources fingerprinted to
prove the merge only reads them:

```
jobs: primary 2 → 21 (expected 21)
transcript paths not profile-scoped: 17/17
source profiles unmodified: 3/3
records reachable after re-linking: 21/21
```

`doctor` on the same machine now reports the profile that previously passed as healthy:

```
claude:personal → healthy                    (before)
claude:personal → 3 issues                   (after)
   agent-dashboard/ is shared in primary but missing here — run 'clausona repair'
   cc-config-backups/ is shared in primary but missing here — run 'clausona repair'
   daemon/ is shared in primary but missing here — run 'clausona repair'
```

## Deliberately unchanged

- **`daemon/`** holds only runtime state (`control.key`, `roster.json`, `dispatch/`) and
  has nothing to merge. It is already shared by default; whether that is right depends on
  how the supervisor resolves `CLAUDE_CONFIG_DIR` for the sessions it spawns, which is
  not established yet.
- **`--continue`** was never broken. It resolves through `projects/`, already shared, and
  `lastSessionId` in `.claude.json` is written for telemetry only — nothing reads it back
  to pick a session.
- **Account-specific files shared by default** (`policy-limits.json`,
  `remote-settings.json`) need their own issue: a write through the shared link lands on
  the primary's copy.

## Recovery for existing profiles

Records already split across silos are merged by `clausona repair <profile>`. Records
whose transcript has since been deleted are moved but cannot be resumed — on the
reporting machine that was 6 of 21.

Patch release: `0.2.0-beta` → `0.2.1-beta`.
