### PR TITLE
fix: detect Node without `which` and check installers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,34 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test
+
+      # The installers ship as release assets and are never exercised by the unit
+      # tests, so a broken one only surfaces when a user runs it.
+      - name: Check installer (POSIX)
+        if: runner.os == 'Linux'
+        run: |
+          bash -n install.sh
+          # Node must be found without `which`, which minimal images do not ship.
+          mkdir -p /tmp/minbin
+          ln -sf "$(command -v node)" /tmp/minbin/node
+          out="$(env PATH=/tmp/minbin /bin/bash install.sh 2>&1 || true)"
+          printf '%s\n' "$out"
+          case "$out" in
+            *"Using node:"*) echo "node detection OK" ;;
+            *) echo "::error::install.sh did not detect node on a PATH without which"; exit 1 ;;
+          esac
+
+      - name: Check installer (PowerShell)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $errors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path install.ps1).Path, [ref]$null, [ref]$errors)
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Host $_.ToString() }
+            throw "install.ps1 has parse errors"
+          }
+          $out = (pwsh -NoProfile -File install.ps1 2>&1 | Out-String)
+          Write-Host $out
+          if ($out -notmatch 'Using node:') { throw "install.ps1 did not detect node" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,19 @@ jobs:
           # Node must be found without `which`, which minimal images do not ship.
           mkdir -p /tmp/minbin
           ln -sf "$(command -v node)" /tmp/minbin/node
+          # The run stops at the CLI gate (no claude/codex on the runner), which is
+          # before any download — so a non-zero exit here is expected.
           out="$(env PATH=/tmp/minbin /bin/bash install.sh 2>&1 || true)"
           printf '%s\n' "$out"
           case "$out" in
-            *"Using node:"*) echo "node detection OK" ;;
-            *) echo "::error::install.sh did not detect node on a PATH without which"; exit 1 ;;
+            *"Using node:"*) : ;;
+            *) echo "::error::install.sh did not resolve a Node on a PATH without which"; exit 1 ;;
           esac
+          case "$out" in
+            *"Downloading clausona"*)
+              echo "::error::install.sh passed the CLI gate with no CLI installed"; exit 1 ;;
+          esac
+          echo "installer checks OK"
 
       - name: Check installer (PowerShell)
         if: runner.os == 'Windows'
@@ -57,6 +64,14 @@ jobs:
             $errors | ForEach-Object { Write-Host $_.ToString() }
             throw "install.ps1 has parse errors"
           }
+          # install.ps1 throws at the CLI gate (no claude/codex on the runner), which is
+          # before any download. That non-zero exit is expected, so $LASTEXITCODE is not
+          # allowed to decide this step - the assertions below are the check.
           $out = (pwsh -NoProfile -File install.ps1 2>&1 | Out-String)
           Write-Host $out
-          if ($out -notmatch 'Using node:') { throw "install.ps1 did not detect node" }
+          if ($out -notmatch 'Using node:') { throw "install.ps1 did not resolve a Node" }
+          if ($out -match 'Downloading clausona') {
+            throw "install.ps1 passed the CLI gate with no CLI installed"
+          }
+          Write-Host "installer checks OK"
+          exit 0

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ macOS/Linux:
 curl -fsSL https://github.com/larcane97/clausona/releases/latest/download/install.sh | bash
 ```
 
+Piping to `bash` does not read your shell profile, so if Node comes from a version
+manager (nvm, fnm, asdf), activate it before running the command.
+
 Windows PowerShell:
 
 ```powershell

--- a/install.ps1
+++ b/install.ps1
@@ -17,19 +17,47 @@ Write-Host ""
 Write-Host "  clausona installer" -ForegroundColor Cyan
 Write-Host ""
 
-$NodeCommand = Get-Command node -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-if (-not $NodeCommand) {
-  throw "Node.js >= 20 is required but was not found."
+# Every node on PATH is considered, not just the first one. With an older node earlier
+# in PATH the installer used to reject the machine even though a supported version was
+# installed further along; install.sh walks all candidates the same way.
+$NodeBin = $null
+$NodeFound = $null
+foreach ($candidate in @(Get-Command node -CommandType Application -All -ErrorAction SilentlyContinue)) {
+  $major = 0
+  try { $major = [int](& $candidate.Source -p "process.versions.node.split('.')[0]") } catch { $major = 0 }
+  if ($major -ge 20) {
+    $NodeBin = $candidate.Source
+    break
+  }
+  # Remember the first too-old install so the failure can name what it found.
+  if ((-not $NodeFound) -and ($major -gt 0)) {
+    $NodeFound = "$(& $candidate.Source --version) at $($candidate.Source)"
+  }
 }
 
-$NodeMajor = [int](& $NodeCommand.Source -p "process.versions.node.split('.')[0]")
-if ($NodeMajor -lt 20) {
-  throw "Node.js >= 20 is required. Found: $(& $NodeCommand.Source --version)"
+if (-not $NodeBin) {
+  $reported = if ($NodeFound) { $NodeFound } else { "no node on PATH" }
+  throw @"
+Node.js >= 20 is required but not found.
+Found: $reported
+
+Install Node 20 or newer, then re-run this installer:
+  winget install OpenJS.NodeJS.LTS
+  https://nodejs.org/en/download
+"@
 }
+
+Write-Host "  Using node: $NodeBin ($(& $NodeBin --version))"
 
 $SupportedCli = Get-Command -Name claude, codex -ErrorAction SilentlyContinue | Select-Object -First 1
 if (-not $SupportedCli) {
-  throw "Install Claude Code CLI or OpenAI Codex CLI before installing clausona."
+  throw @"
+Claude Code CLI or OpenAI Codex CLI is required but neither was found.
+
+Install one of them, then re-run this installer:
+  Claude Code  https://docs.anthropic.com/en/docs/claude-code
+  Codex CLI    https://github.com/openai/codex
+"@
 }
 
 $DownloadUrl = if ($Version -eq "latest") {

--- a/install.sh
+++ b/install.sh
@@ -17,27 +17,55 @@ echo ""
 echo -e "  ${BOLD}clausona installer${RESET}"
 echo ""
 
-# Find Node >= 20
+# Find Node >= 20.
+# PATH is walked directly rather than through `which -a`: `which` is an external
+# command under bash and is absent from minimal Linux images (Debian ships it in
+# debianutils), while busybox's does not accept -a. Either way the lookup returned
+# nothing and the installer reported a missing Node on machines that had one.
 NODE_BIN=""
-for candidate in $(which -a node 2>/dev/null); do
+NODE_FOUND=""
+IFS=: read -ra path_dirs <<< "$PATH"
+for dir in "${path_dirs[@]}"; do
+  [[ -n "$dir" ]] || continue
+  candidate="$dir/node"
+  [[ -f "$candidate" && -x "$candidate" ]] || continue
   ver=$("$candidate" -e "console.log(process.versions.node.split('.')[0])" 2>/dev/null || echo "0")
+  [[ "$ver" =~ ^[0-9]+$ ]] || ver="0"
   if [[ "$ver" -ge 20 ]]; then
     NODE_BIN="$candidate"
     break
+  fi
+  # Remember the first too-old install so the failure can name what it found.
+  if [[ -z "$NODE_FOUND" && "$ver" -gt 0 ]]; then
+    NODE_FOUND="$("$candidate" --version 2>/dev/null) at $candidate"
   fi
 done
 
 if [[ -z "$NODE_BIN" ]]; then
   echo -e "  ${RED}✗${RESET} Node.js >= 20 is required but not found."
-  echo -e "  ${CYAN}Found: $(node --version 2>/dev/null || echo 'none')${RESET}"
+  echo -e "  ${CYAN}Found: ${NODE_FOUND:-no node on PATH}${RESET}"
+  echo ""
+  echo -e "  Install Node 20 or newer, then re-run this installer:"
+  echo -e "    macOS    ${CYAN}brew install node${RESET}"
+  echo -e "    Linux    ${CYAN}https://github.com/nodesource/distributions${RESET}"
+  echo -e "    any OS   ${CYAN}https://nodejs.org/en/download${RESET}"
+  echo ""
+  echo -e "  Using nvm, fnm or asdf? ${CYAN}curl ... | bash${RESET} does not read your shell"
+  echo -e "  profile, so activate the version manager before running this."
   exit 1
 fi
 
-echo -e "  Using node: $NODE_BIN (v$($NODE_BIN -e "console.log(process.version)"))"
+echo -e "  Using node: $NODE_BIN ($($NODE_BIN --version))"
 
 if ! command -v claude &>/dev/null && ! command -v codex &>/dev/null; then
   echo -e "  ${RED}✗${RESET} Claude Code CLI or OpenAI Codex CLI is required but neither was found."
-  echo -e "  ${CYAN}Install one of the supported CLIs, then retry.${RESET}"
+  echo ""
+  echo -e "  Install one of them, then re-run this installer:"
+  echo -e "    Claude Code  ${CYAN}https://docs.anthropic.com/en/docs/claude-code${RESET}"
+  echo -e "    Codex CLI    ${CYAN}https://github.com/openai/codex${RESET}"
+  echo ""
+  echo -e "  Already installed? It must be a real executable on PATH - a shell alias"
+  echo -e "  or function is not visible to ${CYAN}curl ... | bash${RESET}."
   exit 1
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clausona",
-  "version": "0.2.1-beta",
+  "version": "0.2.2-beta",
   "private": true,
   "description": "Switch between multiple Claude Code and OpenAI Codex CLI accounts on one machine",
   "type": "module",


### PR DESCRIPTION
Fixes #14.

## install.sh — `which -a` is not portable

```diff
-for candidate in $(which -a node 2>/dev/null); do
+IFS=: read -ra path_dirs <<< "$PATH"
+for dir in "${path_dirs[@]}"; do
+  candidate="$dir/node"
+  [[ -f "$candidate" && -x "$candidate" ]] || continue
```

The script runs under bash, where `which` is an external command — absent from minimal
Debian images (it lives in `debianutils`), and busybox's does not accept `-a`. The
lookup returned nothing, `NODE_BIN` stayed empty, and the installer exited claiming Node
was missing on a machine that had a supported one.

The replacement keeps the previous semantics: same PATH order, executable files only,
first candidate at major >= 20 wins. Non-numeric version output is coerced to 0 instead
of reaching `[[ -ge ]]`.

Verified against a PATH holding node 22 and no `which`:

```
old:  ✗ Node.js >= 20 is required but not found.
new:  SELECTED=/tmp/minbin/node
```

Both were also run on macOS bash 3.2, which is what `curl | bash` gets there, and they
select the same interpreter in a normal environment.

## install.ps1 — only the first Node was considered

`Select-Object -First 1` meant a machine with node 18 ahead of node 22 on PATH was
rejected, while `install.sh` accepted it. It now iterates `Get-Command node -All` and
takes the first supported one, matching the POSIX installer.

## Messages now carry a remedy

Before:

```
✗ Node.js >= 20 is required but not found.
Found: none
```

After:

```
✗ Node.js >= 20 is required but not found.
Found: v18.20.4 at /usr/bin/node

Install Node 20 or newer, then re-run this installer:
  macOS    brew install node
  Linux    https://github.com/nodesource/distributions
  any OS   https://nodejs.org/en/download

Using nvm, fnm or asdf? curl ... | bash does not read your shell
profile, so activate the version manager before running this.
```

That last paragraph is the failure mode most likely to hit a developer machine. The CLI
gate gained the equivalent note: a `claude` provided only as a shell alias or function
is not visible to the piped shell.

## CI now checks the installers

They ship as release assets and no test ever executed them — which is how the doubled
`v` in `Using node: ... (vv22.22.0)` survived in the output. Fixed here too.

- **Linux** — `bash -n install.sh`, then run it on a PATH containing only a `node`
  symlink (no `which`) and assert `Using node:` appears. The run stops at the CLI gate,
  before any download, so nothing is installed on the runner.
- **Windows** — parse `install.ps1` through `Parser::ParseFile`, then run it and assert
  it resolves a Node.

The Linux step is the regression test for this fix: it fails on the old `which -a` code.

## Verification

- 155 tests pass, lint and typecheck clean
- installer logic tested locally in four states: normal PATH, PATH without `which`, only
  node 18 present, no node at all
- `install.ps1` could not be run locally (no pwsh on this machine) — the new CI step is
  what exercises it, and this PR's Windows run is its first execution

Patch release: `0.2.1-beta` → `0.2.2-beta`. The installers only reach users as release
assets, so this needs a release to take effect.

## Not addressed

Release download counts show `install.sh` fetched ~1.38x as often as `clausona.js` (183
vs 133 all-time). The ratio is steady across every release, which points at people
reading the script before piping it to bash rather than at failed installs — so this PR
is not claiming to recover a large number of lost installations. The bugs are worth
fixing on their own.
